### PR TITLE
//cylinder <axis> <length> <radius1> [<radius2>] <node>

### DIFF
--- a/Chat Commands.md
+++ b/Chat Commands.md
@@ -81,14 +81,18 @@ Add hollow cylinder at WorldEdit position 1 along the x/y/z/? axis with length <
     //hollowcylinder z -12 3 mesecons:mesecon
     //hollowcylinder ? 2 4 stone
 
-### //cylinder x/y/z/? <length> <radius> <node>
+### //cylinder x/y/z/? <length> <radius1> [<radius2>] <node>
 
-Add cylinder at WorldEdit position 1 along the x/y/z/? axis with length <length> and radius <radius>, composed of <node>.
+Add cylinder at WorldEdit position 1 along the x/y/z/? axis with length <length>, base radius <radius1> [and top radius <radius2>], composed of <node>.
 
     //cylinder x +5 8 dirt
     //cylinder y 28 10 default:glass
     //cylinder z -12 3 mesecons:mesecon
     //cylinder ? 2 4 stone
+
+    //cylinder y 10 10 0 water_flowing
+    //cylinder x 6 5 0 dirt
+    //cylinder z 20 10 20 desert_stone
     
 ### //pyramid <height> <node>
 

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -94,7 +94,7 @@ Returns the number of nodes added.
 
 ### worldedit.cylinder(pos, axis, length, radius, nodename)
 
-Adds a cylinder at `pos` along the `axis` axis ("x" or "y" or "z") with length `length` and radius `radius`, composed of `nodename`.
+Adds a cylinder at `pos` along the `axis` axis ("x" or "y" or "z") with length `length`, base radius `radius` (and top radius `radius`), composed of `nodename`.
 
 Returns the number of nodes added.
 

--- a/worldedit/primitives.lua
+++ b/worldedit/primitives.lua
@@ -104,8 +104,8 @@ worldedit.hollow_cylinder = function(pos, axis, length, radius, nodename)
 	return count
 end
 
---adds a cylinder at `pos` along the `axis` axis ("x" or "y" or "z") with length `length` and radius `radius`, composed of `nodename`, returning the number of nodes added
-worldedit.cylinder = function(pos, axis, length, radius, nodename)
+--adds a cylinder at `pos` along the `axis` axis ("x" or "y" or "z") with length `length`, base radius `radius` (and top radius `radius`), composed of `nodename`, returning the number of nodes added
+worldedit.cylinder = function(pos, axis, length, radius1, radius2, nodename)
 	local other1, other2
 	if axis == "x" then
 		other1, other2 = "y", "z"
@@ -125,6 +125,9 @@ worldedit.cylinder = function(pos, axis, length, radius, nodename)
 		step = -1
 	end
 	for i = 1, length do
+		local radius = radius1 + (radius2 - radius1) * (i - 1) / (length - 1)
+		--radius shouldn't need rounding
+		radius = math.floor(radius+0.5)
 		local offset1, offset2 = 0, radius
 		local delta = -radius
 		while offset1 <= offset2 do

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -269,8 +269,8 @@ minetest.register_chatcommand("/hollowcylinder", {
 })
 
 minetest.register_chatcommand("/cylinder", {
-	params = "x/y/z/? <length> <radius> <node>",
-	description = "Add cylinder at WorldEdit position 1 along the x/y/z/? axis with length <length> and radius <radius>, composed of <node>",
+	params = "x/y/z/? <length> <radius1> [<radius2>] <node>",
+	description = "Add cylinder at WorldEdit position 1 along the x/y/z/? axis with length <length>, base radius <radius1> [and top radius <radius2>], composed of <node>",
 	privs = {worldedit=true},
 	func = function(name, param)
 		local pos = worldedit.pos1[name]
@@ -279,10 +279,17 @@ minetest.register_chatcommand("/cylinder", {
 			return
 		end
 
-		local found, _, axis, length, radius, nodename = param:find("^([xyz%?])%s+([+-]?%d+)%s+(%d+)%s+([^%s]+)$")
+		--double radius
+		local found, _, axis, length, radius1, radius2, nodename = param:find("^([xyz%?])%s+([+-]?%d+)%s+(%d+)%s+(%d+)%s+([^%s]+)$")
 		if found == nil then
-			minetest.chat_send_player(name, "Invalid usage: " .. param)
-			return
+			--single radius
+			found, _, axis, length, radius1, nodename = param:find("^([xyz%?])%s+([+-]?%d+)%s+(%d+)%s+([^%s]+)$")
+			if found == nil then
+				--no radius
+				minetest.chat_send_player(name, "Invalid usage: " .. param)
+				return
+			end
+			radius2 = radius1
 		end
 		if axis == "?" then
 			axis, sign = worldedit.player_axis(name)
@@ -293,7 +300,7 @@ minetest.register_chatcommand("/cylinder", {
 			return
 		end
 
-		local count = worldedit.cylinder(pos, axis, tonumber(length), tonumber(radius), nodename)
+		local count = worldedit.cylinder(pos, axis, tonumber(length), tonumber(radius1), tonumber(radius2), nodename)
 		minetest.chat_send_player(name, count .. " nodes added")
 	end,
 })


### PR DESCRIPTION
This is a response to #2.

If there were both `//cylinder` and `//cone` commands, we would be able to make cylinders and cones. But by adding a second base to the cylinder, one can make shapes between cylinders and cones.

**Behavior:**
To make a cylinder, use a single radius: `//cylinder y 20 10 dirt` (default behavior)
To make a cone, use a second radius of zero: `//cylinder y 20 10 0 dirt`
To make a conical cylinder/half-cut cone, use different-sized radii: `//cylinder y 20 5 10 dirt`

![gif animation](http://s16.postimage.org/rnlchfe0h/Conical_Cylinder.gif)

**Note:** Because `diameter = radius + 1 + radius` (also default behavior), to have a "perfect" cone with a 1:1 slope, _<length>_ would be one more than _<radius1>_: `//cylinder y 6 5 0 dirt`

**Complaint:** I found four places I had to edit to change the description of this command: Chat Commands.md, WorldEdit API.md, worldedit/primitives.lua, and worldedit_commands/init.lua. I expected two places at the most.

**Fun:** Run `//cylinder y 20 0 20 air` from 20 below the surface of the ocean! You'll get a (temporary) whirlpool!

**Issue:**
To make the radius go between the two bases, I used this line.
`local radius = radius1 + (radius2 - radius1) * (i - 1) / (length - 1)`
Depending on what _<length>_, _<radius1>_, and _<radius2>_ you give it, sometimes it will have a decimal radius that loop.

The rest of the function doesn't seem to be able to handle a non-int radius. Without rounding the radius, the cone will either
  • either be lopsided to one side of both the x and z axes,
  • or have tunnels going through it,
  • and it will return a decimal node count.

Therefore, as a cop-out, I added this line.
`radius = math.floor(radius+0.5)`
It rounds the radius, creating an obvious ring around the cone when the radius jumps, instead of smoothly increasing in smaller-than-1 increments. This could be fixed, along with the count returned when the radius isn't rounded.

So if this pull request was merged, an issue would come with it, to have it work without having to round the radius.

**Name:** I considered changing the name of the command, but I couldn't think of a single word that would give the idea that it could be a cylinder or a cone or anywhere in between. So I'll just geometrically assume a cone is a cylinder with a base of zero.
