### PR TITLE
Add initial support for Minetest schematic API

### DIFF
--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -4,6 +4,8 @@ worldedit.set_pos = {}
 
 worldedit.pos1 = {}
 worldedit.pos2 = {}
+worldedit.prob_pos  = {}
+worldedit.prob_list = {}
 
 dofile(minetest.get_modpath("worldedit_commands") .. "/mark.lua")
 
@@ -161,6 +163,9 @@ minetest.register_on_punchnode(function(pos, node, puncher)
 			worldedit.mark_pos2(name)
 			worldedit.set_pos[name] = nil --finished setting positions
 			worldedit.player_notify(name, "position 2 set to " .. minetest.pos_to_string(pos))
+		elseif worldedit.set_pos[name] == "prob" then --setting Minetest schematic node probabilities
+			worldedit.prob_pos[name] = pos
+			minetest.show_formspec(puncher:get_player_name(), "prob_val_enter", "field[text;;]")
 		end
 	end
 end)
@@ -1071,3 +1076,94 @@ minetest.register_chatcommand("/luatransform", {
 		end
 	end,
 })
+
+minetest.register_chatcommand("/mtschemcreate", {
+	params = "<filename>",
+	description = "Creates a Minetest schematic of the box defined by position 1 and position 2, and saves it to <filename>",
+	privs = {worldedit=true, server=true},
+	func = function(name, param)
+		local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]
+		if pos1 == nil or pos2 == nil then
+			worldedit.player_notify(name, "no region selected")
+			return
+		end
+		if param == nil then
+			worldedit.player_notify(name, "no filename specified")
+			return
+		end
+
+		local ret = minetest.create_schematic(pos1, pos2, worldedit.prob_list[name], tostring(param))
+		if ret == nil then
+			worldedit.player_notify(name, "Failed to create Minetest schematic", false)
+		else
+			worldedit.player_notify(name, "Saved Minetest schematic to " .. param, false)
+		end
+		worldedit.prob_list[name] = {}
+	end,
+})
+
+minetest.register_chatcommand("/mtschemplace", {
+	params = "<filename>",
+	description = "Places the Minetest schematic identified by <filename> at WorldEdit position 1",
+	privs = {worldedit=true, server=true},
+	func = function(name, param)
+		local pos = worldedit.pos1[name]
+		if pos == nil then
+			worldedit.player_notify(name, "no position selected")
+			return
+		end
+		if param == nil then
+			worldedit.player_notify(name, "no filename specified")
+			return
+		end
+
+		if minetest.place_schematic(pos, param) == nil then
+			worldedit.player_notify(name, "Failed to place Minetest schematic", false)
+		else
+			worldedit.player_notify(name, "Placed Minetest schematic " .. param ..
+				" at " .. minetest.pos_to_string(pos), false)
+		end
+	end,
+})
+
+minetest.register_chatcommand("/mtschemprob", {
+	params = "start/finish/get",
+	description = "Begins node probability entry for Minetest schematics, gets the nodes that have probabilities set, or ends node probability entry",
+	privs = {worldedit=true, server=true},
+	func = function(name, param)
+		if param == "start" then --start probability setting
+			worldedit.set_pos[name] = "prob"
+			worldedit.prob_list[name] = {}
+			worldedit.player_notify(name, "select Minetest schematic probability values by punching nodes")
+		elseif param == "finish" then --finish probability setting
+			worldedit.set_pos[name] = nil
+			worldedit.player_notify(name, "finished Minetest schematic probability selection")
+		elseif param == "get" then --get all nodes that had probabilities set on them
+			local text = ""
+			local problist = worldedit.prob_list[name]
+			if problist == nil then
+				return
+			end
+			for k,v in pairs(problist) do
+				local prob = math.floor(((v["prob"] / 256) * 100) * 100 + 0.5) / 100
+				text = text .. minetest.pos_to_string(v["pos"]) .. ": " .. prob .. "% | "
+			end
+			worldedit.player_notify(name, "Currently set node probabilities:")
+			worldedit.player_notify(name, text)
+		else
+			worldedit.player_notify(name, "unknown subcommand: " .. param)
+		end
+	end,
+})
+
+minetest.register_on_player_receive_fields(
+	function(player, formname, fields)
+		if (formname == "prob_val_enter") and (fields.text ~= "") then
+			local name = player:get_player_name()
+			local prob_entry = {pos=worldedit.prob_pos[name], prob=tonumber(fields.text)}
+			local index = table.getn(worldedit.prob_list[name]) + 1
+			worldedit.prob_list[name][index] = prob_entry
+		end
+	end
+)
+


### PR DESCRIPTION
This patch adds support for creating and placing schematic files using the new schematic API.
Three commands were added:
- /mtschemcreate <filename>

Creates a Minetest schematic file of the nodes on the map in the box from pos1 to pos2, and saves to filename
- /mtschemplace <filename>

Places Minetest schematic from filename onto pos1 of the map.
- /mtschemprob <start/finish/get>

Before running /mtschemcreate, probability values of nodes inside the box can be set.  /mtschemprob start begins the selection process, and node punches thereafter open a formspec with a text entry box to enter the probability value for that node from 0 to 255.  /mtschemprob finish exits this selection mode.  /mtschemprob get displays the probabilities of the nodes that had been modified, pending schematic creation.
