### PR TITLE
Fix incorrect fixedpos var names in the GUI form

### DIFF
--- a/worldedit_gui/functionality.lua
+++ b/worldedit_gui/functionality.lua
@@ -86,12 +86,12 @@ worldedit.register_gui_function("worldedit_gui_region", {
 			string.format("field[2,5;1.5,0.8;worldedit_gui_fixedpos_pos1x;X ;%s]", pos1 and pos1.x or "") ..
 			string.format("field[3.5,5;1.5,0.8;worldedit_gui_fixedpos_pos1y;Y ;%s]", pos1 and pos1.y or "") ..
 			string.format("field[5,5;1.5,0.8;worldedit_gui_fixedpos_pos1z;Z ;%s]", pos1 and pos1.z or "") ..
-			"button_exit[6.5,4.68;2.5,0.8;worldedit_gui_fixed_pos1_submit;Set Position 1]" ..
+			"button_exit[6.5,4.68;2.5,0.8;worldedit_gui_fixedpos_pos1_submit;Set Position 1]" ..
 			"label[0,6.2;Position 2]" ..
 			string.format("field[2,6.5;1.5,0.8;worldedit_gui_fixedpos_pos2x;X ;%s]", pos2 and pos2.x or "") ..
 			string.format("field[3.5,6.5;1.5,0.8;worldedit_gui_fixedpos_pos2y;Y ;%s]", pos2 and pos2.y or "") ..
 			string.format("field[5,6.5;1.5,0.8;worldedit_gui_fixedpos_pos2z;Z ;%s]", pos2 and pos2.z or "") ..
-			"button_exit[6.5,6.18;2.5,0.8;worldedit_gui_fixed_pos2_submit;Set Position 2]"
+			"button_exit[6.5,6.18;2.5,0.8;worldedit_gui_fixedpos_pos2_submit;Set Position 2]"
 	end,
 })
 


### PR DESCRIPTION
worldedit_gui_fixed_\* -> worldedit_gui_fixedpos_*

Makes setting a fixed position in the GUI work correctly
