### PR TITLE
Fix runtime error checking with lua* commands

### DIFF
--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -1,7 +1,9 @@
 worldedit = worldedit or {}
-local minetest = minetest --local copy of global
+local minetest = minetest -- local copy of global
 
---modifies positions `pos1` and `pos2` so that each component of `pos1` is less than or equal to its corresponding conent of `pos2`, returning two new positions
+-- Copies and modifies positions `pos1` and `pos2` so that each component of
+-- `pos1` is less than or equal to the corresponding component of `pos2`.
+-- Returns the new positions.
 worldedit.sort_pos = function(pos1, pos2)
 	pos1 = {x=pos1.x, y=pos1.y, z=pos1.z}
 	pos2 = {x=pos2.x, y=pos2.y, z=pos2.z}
@@ -17,30 +19,33 @@ worldedit.sort_pos = function(pos1, pos2)
 	return pos1, pos2
 end
 
---executes `code` as a Lua chunk in the global namespace, returning an error if the code fails or nil otherwise
+-- Executes `code` as a Lua chunk in the global namespace,
+-- returning an error if the code fails, or nil otherwise.
 worldedit.lua = function(code)
-	local operation, message = loadstring(code)
-	if operation == nil then --code parsing failed
-		return message
+	local func, err = loadstring(code)
+	if not func then  -- Syntax error
+		return err
 	end
-	local status, message = pcall(operation)
-	if status == nil then --operation failed
-		return message
+	local good, err = pcall(operation)
+	if not good then  -- Runtime error
+		return err
 	end
 	return nil
 end
 
---executes `code` as a Lua chunk in the global namespace with the variable pos available, for each node in a region defined by positions `pos1` and `pos2`, returning an error if the code fails or nil otherwise
+-- Executes `code` as a Lua chunk in the global namespace with the variable
+-- pos available, for each node in a region defined by positions `pos1` and
+-- `pos2`, returning an error if the code fails, or nil otherwise
 worldedit.luatransform = function(pos1, pos2, code)
-	local pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 
-	local factory, message = loadstring("return function(pos) " .. code .. " end")
-	if factory == nil then --code parsing failed
-		return message
+	local factory, err = loadstring("return function(pos) " .. code .. " end")
+	if not factory then  -- Syntax error
+		return err
 	end
-	local operation = factory()
+	local func = factory()
 
-	--make area stay loaded
+	-- Keep area loaded
 	local manip = minetest.get_voxel_manip()
 	manip:read_from_map(pos1, pos2)
 
@@ -50,9 +55,9 @@ worldedit.luatransform = function(pos1, pos2, code)
 		while pos.y <= pos2.y do
 			pos.z = pos1.z
 			while pos.z <= pos2.z do
-				local status, message = pcall(operation, pos)
-				if status == nil then --operation failed
-					return message
+				local good, err = pcall(func, pos)
+				if not good then -- Runtime error
+					return err
 				end
 				pos.z = pos.z + 1
 			end
@@ -62,3 +67,4 @@ worldedit.luatransform = function(pos1, pos2, code)
 	end
 	return nil
 end
+

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -1,7 +1,9 @@
 worldedit = worldedit or {}
 local minetest = minetest --local copy of global
 
---modifies positions `pos1` and `pos2` so that each component of `pos1` is less than or equal to its corresponding conent of `pos2`, returning two new positions
+-- Copies and modifies positions `pos1` and `pos2` so that each component of
+-- `pos1` is less than or equal to the corresponding component of `pos2`.
+-- Returns the new positions.
 worldedit.sort_pos = function(pos1, pos2)
 	pos1 = {x=pos1.x, y=pos1.y, z=pos1.z}
 	pos2 = {x=pos2.x, y=pos2.y, z=pos2.z}


### PR DESCRIPTION
"It's first result is the status code (a boolean), which is true if the call succeeds without errors. [...] In case of any error, pcall returns _**`false`**_ [not `nil`] plus the error message." -- Lua 5.1 manual

I also made some stylistic and commenting changes:
- ~80 char comment/code wrap.
- Capital letter starting comments.
- Space between comment character(s) and first word.

But noticed that more are needed:
- `func = function()` -> `function func()`.
- Less commas in comment sentences.

You may or may not agree with all of these, but I find that they make the code much more readable and it's Minetest's code style.

Also, should probably be done but unrelated:
- `sort_pos` copies positions, which is probably wastefull.
- The module system needs work, because `code` depends on `manipulations` for `sort_pos`, maybe this should be in `init`.

**Edit:**
- The `/` command namespace is far too generic, it's also easy to start typing builtin commands with the extra `/` or vice-versa.
