### PR TITLE
Clean up serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,20 +109,24 @@ WorldEdit supports two different types of schematics.
 
 The first is the WorldEdit Schematic format, with the file extension ".we", and in some older versions, ".wem". There have been several previous versions of the WorldEdit Schematic format, but WorldEdit is capable of loading any past versions, and will always support them - there is no need to worry about schematics becoming obselete.
 
-The current version of the WorldEdit Schematic format, internally known as version 4, is essentially an array of node data tables in Lua 5.2 table syntax. Specifically:
+As of version 5, WorldEdit schematics include a header.  The header is seperated from the content by a colon (`:`).  It contains fields seperated by commas (`,`).  Currently only one field is used, which contains the version in ASCII decimal.
 
-    return {
-        {
-            ["y"]      = <y-axis coordinate>,
-            ["x"]      = <x-axis coordinate>,
-            ["name"]   = <node name>,
-            ["z"]      = <z-axis coordinate>,
-            ["meta"]   = <metadata table>,
-            ["param2"] = <param2 value>,
-            ["param1"] = <y-axis coordinate>,
-        },
-        <...>
-    }
+The current version of the WorldEdit Schematic format is essentially an array of node data tables in Lua 5.1 table syntax preceded by a header.
+Specifically it looks like this:
+
+	5:return {
+		{
+			y      = <y-axis coordinate>,
+			x      = <x-axis coordinate>,
+			z      = <z-axis coordinate>,
+			name   = <node name>,
+			param1 = <param1 value>,
+			param2 = <param2 value>,
+			meta   = <metadata table>,
+		},
+		<...>
+	}
+
 
 The ordering of the values and minor aspects of the syntax, such as trailing commas or newlines, are not guaranteed to stay the same in future versions.
 

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -195,29 +195,30 @@ Serialization
 -------------
 Contained in serialization.lua, this module allows regions of nodes to be serialized and deserialized to formats suitable for use outside MineTest.
 
-### version = worldedit.valueversion(value)
+### version, extra_fields, content = worldedit.read_header(value)
 
-Determines the version of serialized data `value`.
+Reads the header from serialized data `value`.
 
-Returns the version as a positive integer or 0 for unknown versions.
+Returns the version as a positive integer (nil for unknown versions),
+extra header fields (nil if not supported), and the content after the header.
 
 ### data, count = worldedit.serialize(pos1, pos2)
 
 Converts the region defined by positions `pos1` and `pos2` into a single string.
 
-Returns the serialized data and the number of nodes serialized.
+Returns the serialized data and the number of nodes serialized, or nil.
 
-### pos1, pos2, count = worldedit.allocate(originpos, value)
+### pos1, pos2, count = worldedit.allocate(origin_pos, value)
 
-Determines the volume the nodes represented by string `value` would occupy if deserialized at `originpos`.
+Determines the volume the nodes represented by string `value` would occupy if deserialized at `origin_pos`.
 
-Returns the two corner positions and the number of nodes.
+Returns the two corner positions and the number of nodes, or nil.
 
-### count = worldedit.deserialize(originpos, value)
+### count = worldedit.deserialize(origin_pos, value)
 
-Loads the nodes represented by string `value` at position `originpos`.
+Loads the nodes represented by string `value` at position `origin_pos`.
 
-Returns the number of nodes deserialized.
+Returns the number of nodes deserialized or nil.
 
 Code
 ----

--- a/worldedit/compatibility.lua
+++ b/worldedit/compatibility.lua
@@ -2,7 +2,9 @@ worldedit = worldedit or {}
 local minetest = minetest --local copy of global
 
 worldedit.allocate_old = worldedit.allocate
+
 worldedit.deserialize_old = worldedit.deserialize
+
 worldedit.metasave = function(pos1, pos2, filename)
 	local file, err = io.open(filename, "wb")
 	if err then return 0 end
@@ -11,6 +13,7 @@ worldedit.metasave = function(pos1, pos2, filename)
 	file:close()
 	return count
 end
+
 worldedit.metaload = function(originpos, filename)
 	filename = minetest.get_worldpath() .. "/schems/" .. file .. ".wem"
 	local file, err = io.open(filename, "wb")
@@ -18,6 +21,16 @@ worldedit.metaload = function(originpos, filename)
 	local data = file:read("*a")
 	return worldedit.deserialize(originpos, data)
 end
+
 worldedit.scale = function(pos1, pos2, factor)
 	return worldedit.stretch(pos1, pos2, factor, factor, factor)
 end
+
+worldedit.valueversion = function(value)
+	local version = worldedit.read_header(value)
+	if not version or version > worldedit.LATEST_SERIALIZATION_VERSION then
+		return 0
+	end
+	return version
+end
+

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -911,9 +911,12 @@ minetest.register_chatcommand("/allocate", {
 		local value = file:read("*a")
 		file:close()
 
-		if worldedit.valueversion(value) == 0 then --unknown version
-			worldedit.player_notify(name, "invalid file: file is invalid or created with newer version of WorldEdit")
+		local version = worldedit.read_header(value)
+		if version == 0 then
+			worldedit.player_notify(name, "File is invalid!")
 			return
+		elseif version > worldedit.LATEST_SERIALIZATION_VERSION then
+			worldedit.player_notify(name, "File was created with newer version of WorldEdit!")
 		end
 		local nodepos1, nodepos2, count = worldedit.allocate(pos, value)
 
@@ -963,8 +966,12 @@ minetest.register_chatcommand("/load", {
 		local value = file:read("*a")
 		file:close()
 
-		if worldedit.valueversion(value) == 0 then --unknown version
-			worldedit.player_notify(name, "invalid file: file is invalid or created with newer version of WorldEdit")
+		local version = worldedit.read_header(value)
+		if version == 0 then
+			worldedit.player_notify(name, "File is invalid!")
+			return
+		elseif version > worldedit.LATEST_SERIALIZATION_VERSION then
+			worldedit.player_notify(name, "File was created with newer version of WorldEdit!")
 			return
 		end
 


### PR DESCRIPTION
This does a number of things:
- Adds a header to serialized data (to make version checking sane).
- Removes the duplicate deserialization for `worldedit.deserialize` and `worldedit.allocate`.
- Optimizes `worldedit.deserialize` by only deserializing the data once.
- Includes a cleaner version of #59 (make some fields optional).
- Cleans up the comments and a little of the code style.
- Partially breaks the API for some functions (probably not a big deal since I don't know of any external mods that use the API).
- Probably a few other things that I've forgotten.
