### PR TITLE
6D Facedir management and automatic orientation during flip and rotate

### DIFF
--- a/ChatCommands.md
+++ b/ChatCommands.md
@@ -276,14 +276,13 @@ Rotate the current WorldEdit positions and region along the x/y/z/? axis by angl
     //rotate z 270
     //rotate ? -90
 
-### `//orient <angle>`
+### `//orient <operation> <axis> <angle>`
 
-Rotate oriented nodes in the current WorldEdit region around the Y axis by angle `<angle>` (90 degree increment)
+Change orientation of all oriented nodes in the current WorldEdit region performing <operation> (rotate or flip) around the <axis> axis by angle <angle> (90 degree increment, unused for flip operation).
 
-    //orient 90
-    //orient 180
-    //orient 270
-    //orient -90
+	//orient rotate x 90
+	//orient rotate y -90
+	//orient flip x 0
 
 ### `//fixlight`
 

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -87,9 +87,9 @@ Rotates a region defined by the positions `pos1` and `pos2` by `angle` degrees c
 
 Returns the number of nodes rotated, the new position 1, and the new position 2.
 
-### count = worldedit.orient(pos1, pos2, angle)
+### count = worldedit.orient(pos1, pos2, operation, axis, angle)
 
-Rotates all oriented nodes in a region defined by the positions `pos1` and `pos2` by `angle` degrees clockwise (90 degree increment) around the Y axis.
+Change orientation of all oriented nodes in a region defined by the positions `pos1` and `pos2` performing `operation` (rotate or flip) around the `axis` axis by angle `angle` (90 degree increment, unused for flip operation)
 
 Returns the number of nodes oriented.
 

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -4,6 +4,56 @@
 local mh = worldedit.manip_helpers
 
 
+local facedir_substitutions = {
+	['flip'] = {
+		['x'] = {[0]=0, 3, 2, 1, 4, 5, 6, 7, 8, 11, 10, 9, 16, 19, 18, 17, 12, 15, 14, 13, 20, 23, 22, 21},
+		['y'] = {[0]=20, 23, 22, 21, 6, 5, 4, 7, 10, 9, 8, 11, 12, 15, 14, 13, 16, 19, 18, 17, 0, 3, 2, 1},
+		['z'] = {[0]=2, 1, 0, 3, 10, 9, 8, 11, 6, 5, 4, 7, 14, 13, 12, 15, 18, 17, 16, 19, 22, 21, 20, 23}
+	},
+	['rotate'] = {
+		['x'] = {
+			[90] = {[0]=8, 9, 10, 11, 0, 1, 2, 3, 22, 23, 20, 21, 15, 12, 13, 14, 17, 18, 19, 16, 6, 7, 4, 5},
+			[180] = {[0]=22, 23, 20, 21, 8, 9, 10, 11, 4, 5, 6, 7, 14, 15, 12, 13, 18, 19, 16, 17, 2, 3, 0, 1},
+			[270] = {[0]=4, 5, 6, 7, 22, 23, 20, 21, 0, 1, 2, 3, 13, 14, 15, 12, 19, 16, 17, 18, 10, 11, 8, 9}
+		},
+		['y'] = {
+			[90] = {[0]=1, 2, 3, 0, 13, 14, 15, 12, 17, 18, 18, 16, 9, 10, 11, 8, 5, 6, 7, 4, 23, 20, 21, 22},
+			[180] = {[0]=2, 3, 0, 1, 10, 11, 8, 9, 6, 7, 7, 5, 18, 18, 16, 17, 14, 15, 12, 13, 22, 23, 20, 21},
+			[270] = {[0]=3, 0, 1, 2, 18, 16, 17, 18, 15, 12, 12, 14, 7, 7, 5, 6, 11, 8, 9, 10, 21, 22, 23, 20}
+		},
+		['z'] = {
+			[90] = {[0]=12, 13, 14, 15, 7, 4, 5, 6, 9, 10, 11, 8, 20, 21, 22, 23, 0, 1, 2, 3, 16, 17, 18, 19},
+			[180] = {[0]=20, 21, 22, 23, 6, 7, 4, 5, 10, 11, 8, 9, 16, 17, 18, 19, 12, 13, 14, 15, 0, 1, 2, 3},
+			[270] = {[0]=16, 17, 18, 19, 5, 6, 7, 4, 11, 8, 9, 10, 0, 1, 2, 3, 20, 21, 22, 23, 12, 13, 14, 15}
+		}
+	}
+}
+
+local wallmounted_substitutions = {
+	['flip'] = {
+		['x'] = {[0]=1, 0, 3, 2, 4, 5},
+		['y'] = {[0]=0, 1, 2, 3, 4, 5},
+		['z'] = {[0]=0, 1, 2, 3, 5, 4}
+	},
+	['rotate'] = {
+		['x'] = {
+			[90] = {[0]=5, 4, 2, 3, 0, 1},
+			[180] = {[0]=1, 0, 2, 3, 5, 4},
+			[270] = {[0]=4, 5, 2, 3, 1, 0}
+		},
+		['y'] = {
+			[90] = {[0]=0, 1, 5, 4, 2, 3},
+			[180] = {[0]=0, 1, 3, 2, 5, 4},
+			[270] = {[0]=0, 1, 4, 5, 3, 2}
+		},
+		['z'] = {
+			[90] = {[0]=2, 3, 1, 0, 4, 5},
+			[180] = {[0]=1, 0, 3, 2, 4, 5},
+			[270] = {[0]=3, 2, 0, 1, 4, 5}
+		}
+	}
+}
+
 --- Sets a region to `node_names`.
 -- @param pos1
 -- @param pos2
@@ -336,7 +386,6 @@ function worldedit.stretch(pos1, pos2, stretch_x, stretch_y, stretch_z)
 	return worldedit.volume(pos1, pos2) * stretch_x * stretch_y * stretch_z, pos1, new_pos2
 end
 
-
 --- Transposes a region between two axes.
 -- @return The number of nodes transposed.
 -- @return The new transposed position 1.
@@ -399,9 +448,9 @@ function worldedit.transpose(pos1, pos2, axis1, axis2)
 end
 
 
---- Flips a region along `axis`.
+--- Flips a region along `axis`. Flips only nodes, no change on nodes orientations
 -- @return The number of nodes flipped.
-function worldedit.flip(pos1, pos2, axis)
+function worldedit.flipnodes(pos1, pos2, axis)
 	local pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 
 	worldedit.keep_loaded(pos1, pos2)
@@ -437,68 +486,42 @@ function worldedit.flip(pos1, pos2, axis)
 	return worldedit.volume(pos1, pos2)
 end
 
-
---- Rotates a region clockwise around an axis.
+--- Change orientation of all oriented nodes in a region.
 -- @param pos1
 -- @param pos2
--- @param axis Axis ("x", "y", or "z").
--- @param angle Angle in degrees (90 degree increments only).
--- @return The number of nodes rotated.
--- @return The new first position.
--- @return The new second position.
-function worldedit.rotate(pos1, pos2, axis, angle)
-	local pos1, pos2 = worldedit.sort_pos(pos1, pos2)
-
-	local other1, other2 = worldedit.get_axis_others(axis)
-	angle = angle % 360
-
-	local count
-	if angle == 90 then
-		worldedit.flip(pos1, pos2, other1)
-		count, pos1, pos2 = worldedit.transpose(pos1, pos2, other1, other2)
-	elseif angle == 180 then
-		worldedit.flip(pos1, pos2, other1)
-		count = worldedit.flip(pos1, pos2, other2)
-	elseif angle == 270 then
-		worldedit.flip(pos1, pos2, other2)
-		count, pos1, pos2 = worldedit.transpose(pos1, pos2, other1, other2)
-	else
-		error("Only 90 degree increments are supported!")
-	end
-	return count, pos1, pos2
-end
-
-
---- Rotates all oriented nodes in a region clockwise around the Y axis.
--- @param pos1
--- @param pos2
+-- @param operation Kind of operation : flip or rotate.
+-- @param axis Orientation axis : x, y or z
 -- @param angle Angle in degrees (90 degree increments only).
 -- @return The number of nodes oriented.
--- TODO: Support 6D facedir rotation along arbitrary axis.
-function worldedit.orient(pos1, pos2, angle)
+--- TODO : When flipping, try to manage diametral symetric nodes (should be rotated instead of flipped)
+function worldedit.orient(pos1, pos2, operation, axis, angle)
 	local pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 	local registered_nodes = minetest.registered_nodes
 
-	local wallmounted = {
-		[90]  = {[0]=0, 1, 5, 4, 2, 3},
-		[180] = {[0]=0, 1, 3, 2, 5, 4},
-		[270] = {[0]=0, 1, 4, 5, 3, 2}
-	}
-	local facedir = {
-		[90]  = {[0]=1, 2, 3, 0},
-		[180] = {[0]=2, 3, 0, 1},
-		[270] = {[0]=3, 0, 1, 2}
-	}
+	if axis ~= 'x' and axis ~= 'y' and axis ~= 'z' then
+		error("Axis should be 'x', 'y' or 'z'!")
+	end
 
-	angle = angle % 360
-	if angle == 0 then
-		return 0
+	local facedir_substitution
+	local wallmounted_substitution
+
+	if operation == "rotate" then	
+		angle = angle % 360
+		if angle == 0 then
+			return
+		else
+			if angle % 90 ~= 0 then
+				error("Only 90 degree increments are supported!")
+			end
+			facedir_substitution = facedir_substitutions[operation][axis][angle]
+			wallmounted_substitution = wallmounted_substitutions[operation][axis][angle]
+		end
+  	elseif operation == "flip" then
+		facedir_substitution = facedir_substitutions[operation][axis]
+		wallmounted_substitution = wallmounted_substitutions[operation][axis]
+	else
+		error("Operation should be 'rotate' or 'flip'!")
 	end
-	if angle % 90 ~= 0 then
-		error("Only 90 degree increments are supported!")
-	end
-	local wallmounted_substitution = wallmounted[angle]
-	local facedir_substitution = facedir[angle]
 
 	worldedit.keep_loaded(pos1, pos2)
 
@@ -537,6 +560,48 @@ function worldedit.orient(pos1, pos2, angle)
 	return count
 end
 
+--- Rotates a region clockwise around an axis. Oriented nodes are rotated accordingly.
+-- @param pos1
+-- @param pos2
+-- @param axis Axis ("x", "y", or "z").
+-- @param angle Angle in degrees (90 degree increments only).
+-- @return The number of nodes rotated.
+-- @return The new first position.
+-- @return The new second position.
+function worldedit.rotate(pos1, pos2, axis, angle)
+	local pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+
+	local other1, other2 = worldedit.get_axis_others(axis)
+	angle = angle % 360
+
+	local count
+	if angle == 90 then
+		worldedit.flipnodes(pos1, pos2, other1)
+		count, pos1, pos2 = worldedit.transpose(pos1, pos2, other1, other2)
+	elseif angle == 180 then
+		worldedit.flipnodes(pos1, pos2, other1)
+		count = worldedit.flipnodes(pos1, pos2, other2)
+	elseif angle == 270 then
+		worldedit.flipnodes(pos1, pos2, other2)
+		count, pos1, pos2 = worldedit.transpose(pos1, pos2, other1, other2)
+	else
+		error("Only 90 degree increments are supported!")
+	end
+	worldedit.orient(pos1, pos2, "rotate", axis, angle)
+	return count, pos1, pos2
+end
+
+--- Flips a region along `axis`. Oriented nodes are flipped accordingly.
+-- @param pos1
+-- @param pos2
+-- @param axis Axis ("x", "y", or "z").
+-- @return The number of nodes flipped.
+function worldedit.flip(pos1, pos2, axis)
+	local count
+	count = worldedit.flipnodes(pos1, pos2, axis)
+	worldedit.orient(pos1, pos2, "flip", axis, 0)
+	return count
+end
 
 --- Attempts to fix the lighting in a region.
 -- @return The number of nodes updated.

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -806,20 +806,26 @@ minetest.register_chatcommand("/rotate", {
 })
 
 minetest.register_chatcommand("/orient", {
-	params = "<angle>",
-	description = "Rotate oriented nodes in the current WorldEdit region around the Y axis by angle <angle> (90 degree increment)",
+	params = "<operation> <axis> <angle>",
+	description = "Change orientation of all oriented nodes in the current WorldEdit region performing <operation> (rotate or flip) around the <axis> axis by angle <angle> (90 degree increment, unused for flip operation)",
 	privs = {worldedit=true},
 	func = safe_region(function(name, param)
-		local found, _, angle = param:find("^([+-]?%d+)$")
-		local count = worldedit.orient(worldedit.pos1[name], worldedit.pos2[name], angle)
+		local found, _, operation, axis, angle = param:find("^(.+)%s+([xyz%?])%s+([+-]?%d+)$")
+		if axis == "?" then axis = worldedit.player_axis(name) end
+		local count = worldedit.orient(worldedit.pos1[name], worldedit.pos2[name], operation, axis, angle)
 		worldedit.player_notify(name, count .. " nodes oriented")
 	end,
 	function(name, param)
-		local found, _, angle = param:find("^([+-]?%d+)$")
+		local found, _, operation, axis, angle = param:find("^(.+)%s+([xyz%?])%s+([+-]?%d+)$")
 		if found == nil then
 			worldedit.player_notify(name, "invalid usage: " .. param)
 			return nil
 		end
+		if operation ~= 'flip' and operation ~= 'rotate' then
+			worldedit.player_notify(name, "invalid usage: operation must be flip or rotate")
+			return nil
+		end
+
 		if angle % 90 ~= 0 then
 			worldedit.player_notify(name, "invalid usage: angle must be multiple of 90")
 			return nil

--- a/worldedit_gui/functionality.lua
+++ b/worldedit_gui/functionality.lua
@@ -10,10 +10,10 @@ local gui_count1 = {} --mapping of player names to a quantity (arbitrary strings
 local gui_count2 = {} --mapping of player names to a quantity (arbitrary strings may also appear as values)
 local gui_count3 = {} --mapping of player names to a quantity (arbitrary strings may also appear as values)
 local gui_angle = {} --mapping of player names to an angle (one of 90, 180, 270, representing the angle in degrees clockwise)
+local gui_operation = {} -- mapping of player names to operations (flip or rotate, see orient command)
 local gui_filename = {} --mapping of player names to file names (arbitrary strings may also appear as values)
 local gui_formspec = {} --mapping of player names to formspecs
 local gui_code = {} --mapping of player names to formspecs
-
 --set default values
 setmetatable(gui_nodename1, {__index = function() return "Cobblestone" end})
 setmetatable(gui_nodename2, {__index = function() return "Stone" end})
@@ -26,6 +26,7 @@ setmetatable(gui_count1,     {__index = function() return "3" end})
 setmetatable(gui_count2,     {__index = function() return "6" end})
 setmetatable(gui_count3,     {__index = function() return "4" end})
 setmetatable(gui_angle,     {__index = function() return 90 end})
+setmetatable(gui_operation, {__index = function() return 1 end})
 setmetatable(gui_filename,  {__index = function() return "building" end})
 setmetatable(gui_formspec,  {__index = function() return "size[5,5]\nlabel[0,0;Hello, world!]" end})
 setmetatable(gui_code,  {__index = function() return "minetest.chat_send_player(\"singleplayer\", \"Hello, world!\")" end})
@@ -39,6 +40,11 @@ local angle_indices = {["90 degrees"]=1, ["180 degrees"]=2, ["270 degrees"]=3}
 local angle_values = {90, 180, 270}
 setmetatable(angle_indices, {__index = function () return 1 end})
 setmetatable(angle_values, {__index = function () return 90 end})
+
+local operation_indices = {["Rotate"]=1, ["Flip"]=2}
+local operation_values = {"rotate", "flip"}
+setmetatable(operation_indices, {__index = function () return 1 end})
+setmetatable(operation_values, {__index = function () return "rotate" end})
 
 --given multiple sets of privileges, produces a single set of privs that would have the same effect as requiring all of them at the same time
 local combine_privs = function(...)
@@ -486,18 +492,22 @@ end)
 worldedit.register_gui_function("worldedit_gui_orient", {
 	name = "Orient", privs = minetest.chatcommands["/orient"].privs,
 	get_formspec = function(name)
-		local angle = gui_angle[name]
-		return "size[5,3]" .. worldedit.get_formspec_header("worldedit_gui_orient") ..
-			string.format("dropdown[0,1;2.5;worldedit_gui_orient_angle;90 degrees,180 degrees,270 degrees;%s]", angle) ..
+		local operation, axis, angle = gui_operation[name], gui_axis1[name], gui_angle[name]
+		return "size[8.5,3]" .. worldedit.get_formspec_header("worldedit_gui_orient") ..
+			string.format("dropdown[0,1;2.5;worldedit_gui_orient_operation;Rotate,Flip;%d]", operation) ..
+			string.format("dropdown[3,1;2.5;worldedit_gui_orient_axis;X axis,Y axis,Z axis,Look direction;%d]", axis) ..
+			string.format("dropdown[6,1;2.5;worldedit_gui_orient_angle;90 degrees,180 degrees,270 degrees;%s]", angle) ..
 			"button_exit[0,2.5;3,0.8;worldedit_gui_orient_submit;Orient]"
 	end,
 })
 
 worldedit.register_gui_handler("worldedit_gui_orient", function(name, fields)
 	if fields.worldedit_gui_orient_submit then
+		gui_operation[name] = operation_indices[fields.worldedit_gui_orient_operation]
+		gui_axis1[name] = axis_indices[fields.worldedit_gui_orient_axis]
 		gui_angle[name] = angle_indices[fields.worldedit_gui_orient_angle]
 		worldedit.show_page(name, "worldedit_gui_orient")
-		minetest.chatcommands["/orient"].func(name, angle_values[gui_angle[name]])
+		minetest.chatcommands["/orient"].func(name, string.format("%s %s %s", operation_values[gui_operation[name]], axis_values[gui_axis1[name]], angle_values[gui_angle[name]]))
 		return true
 	end
 	return false


### PR DESCRIPTION
Hello, 

Here is a pull request for adding 6D facedir management. 6D facedir is managed in orient function for rotate and flip operations.

Orient function/command has been modified so it takes two more parameters : the kind of operation (flip or rotate) and the axis.

I also changed rotate and flip so they automatically orient facedir and wallmount of rotated/flipped nodes. flip function has been split in "flipnodes" which flips node but don't do any orientation and "flip" that does both.

There is still an issue with "flip" orientation and diagonal symmetric nodes (roof corners...) which should be rotated instead of flipped.