### PR TITLE
Quality of Service

### DIFF
--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -1,5 +1,7 @@
 minetest.register_privilege("worldedit", "Can use WorldEdit commands")
 
+minetest.register_privilege("worldedit_huge", "Can confirm WorldEdit commands on huge regions")
+
 worldedit.set_pos = {}
 worldedit.inspect = {}
 

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -2,6 +2,8 @@ minetest.register_privilege("worldedit", "Can use WorldEdit commands")
 
 minetest.register_privilege("worldedit_huge", "Can confirm WorldEdit commands on huge regions")
 
+minetest.register_privilege("worldedit_global", "Can use WorldEdit commands affecting the global state")
+
 worldedit.set_pos = {}
 worldedit.inspect = {}
 
@@ -993,7 +995,10 @@ minetest.register_chatcommand("/restore", {
 minetest.register_chatcommand("/save", {
 	params = "<file>",
 	description = "Save the current WorldEdit region to \"(world folder)/schems/<file>.we\"",
-	privs = {worldedit=true},
+	privs = {
+		worldedit=true,
+		worldedit_global=true,
+	},
 	func = safe_region(function(name, param)
 		if param == "" then
 			worldedit.player_notify(name, "invalid usage: " .. param)
@@ -1027,7 +1032,10 @@ minetest.register_chatcommand("/save", {
 minetest.register_chatcommand("/allocate", {
 	params = "<file>",
 	description = "Set the region defined by nodes from \"(world folder)/schems/<file>.we\" as the current WorldEdit region",
-	privs = {worldedit=true},
+	privs = {
+		worldedit=true,
+		worldedit_global=true,
+	},
 	func = function(name, param)
 		local pos = get_position(name)
 		if pos == nil then return end
@@ -1071,7 +1079,10 @@ minetest.register_chatcommand("/allocate", {
 minetest.register_chatcommand("/load", {
 	params = "<file>",
 	description = "Load nodes from \"(world folder)/schems/<file>[.we[m]]\" with position 1 of the current WorldEdit region as the origin",
-	privs = {worldedit=true},
+	privs = {
+		worldedit=true,
+		worldedit_global=true,
+	},
 	func = function(name, param)
 		local pos = get_position(name)
 		if pos == nil then return end
@@ -1156,7 +1167,10 @@ minetest.register_chatcommand("/mtschemcreate", {
 	params = "<file>",
 	description = "Save the current WorldEdit region using the Minetest "..
 		"Schematic format to \"(world folder)/schems/<filename>.mts\"",
-	privs = {worldedit=true},
+	privs = {
+		worldedit=true,
+		worldedit_global=true,
+	},
 	func = safe_region(function(name, param)
 		if param == nil then
 			worldedit.player_notify(name, "No filename specified")
@@ -1187,7 +1201,10 @@ minetest.register_chatcommand("/mtschemcreate", {
 minetest.register_chatcommand("/mtschemplace", {
 	params = "<file>",
 	description = "Load nodes from \"(world folder)/schems/<file>.mts\" with position 1 of the current WorldEdit region as the origin",
-	privs = {worldedit=true},
+	privs = {
+		worldedit=true,
+		worldedit_global=true,
+	},
 	func = function(name, param)
 		if param == "" then
 			worldedit.player_notify(name, "no filename specified")

--- a/worldedit_commands/safe.lua
+++ b/worldedit_commands/safe.lua
@@ -37,6 +37,7 @@ end
 minetest.register_chatcommand("/y", {
 	params = "",
 	description = "Confirm a pending operation",
+	privs = {worldedit_huge=true},
 	func = function(name)
 		local callback, param = safe_region_callback[name], safe_region_param[name]
 		if not callback then


### PR DESCRIPTION
This pull request is part of an effort to enable the usage of WorldEdit for less privileged (non-admin) players on a server without risking disruption of the world as a whole.

In this specific case, huge edits (those which require confirmation due to safe.lua) require an extra privilege (worldedit_huge) to confirm. This is to prevent players having the worldedit privilege from creating requests that hang the server for a long time.

Also, the worldedit_global privileg is required to loading/saving from/to the schems folder since this is global. An interesting alternative approach might be to have per-player schems namespaces.