### PR TITLE
areas integration

### DIFF
--- a/worldedit_commands/depends.txt
+++ b/worldedit_commands/depends.txt
@@ -1,1 +1,2 @@
 worldedit
+areas?

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -13,7 +13,7 @@ end
 dofile(minetest.get_modpath("worldedit_commands") .. "/cuboid.lua")
 dofile(minetest.get_modpath("worldedit_commands") .. "/mark.lua")
 dofile(minetest.get_modpath("worldedit_commands") .. "/wand.lua")
-local safe_region, check_region, reset_pending = dofile(minetest.get_modpath("worldedit_commands") .. "/safe.lua")
+local safe_region, check_region, reset_pending, area_protection = dofile(minetest.get_modpath("worldedit_commands") .. "/safe.lua")
 
 local function get_position(name) --position 1 retrieval function for when not using `safe_region`
 	local pos1 = worldedit.pos1[name]
@@ -409,6 +409,13 @@ minetest.register_chatcommand("/mix", {
 })
 
 local check_replace = function(name, param)
+	if nil ~= area_protection.areas then
+		worldedit.player_notify(
+			name,
+			"check_replace not yet supported with area protection"
+		)
+		return nil
+	end
 	local found, _, searchnode, replacenode = param:find("^([^%s]+)%s+(.+)$")
 	if found == nil then
 		worldedit.player_notify(name, "invalid usage: " .. param)
@@ -456,8 +463,11 @@ minetest.register_chatcommand("/replaceinverse", {
 })
 
 local check_sphere = function(name, param)
-	if worldedit.pos1[name] == nil then
-		worldedit.player_notify(name, "no position 1 selected")
+	if nil ~= area_protection.areas then
+		worldedit.player_notify(
+			name,
+			"check_sphere not yet supported with area protection"
+		)
 		return nil
 	end
 	local found, _, radius, nodename = param:find("^(%d+)%s+(.+)$")
@@ -495,6 +505,13 @@ minetest.register_chatcommand("/sphere", {
 })
 
 local check_dome = function(name, param)
+	if nil ~= area_protection.areas then
+		worldedit.player_notify(
+			name,
+			"check_dome not yet supported with area protection"
+		)
+		return nil
+	end
 	if worldedit.pos1[name] == nil then
 		worldedit.player_notify(name, "no position 1 selected")
 		return nil
@@ -534,6 +551,13 @@ minetest.register_chatcommand("/dome", {
 })
 
 local check_cylinder = function(name, param)
+	if nil ~= area_protection.areas then
+		worldedit.player_notify(
+			name,
+			"check_cylinder not yet supported with area protection"
+		)
+		return nil
+	end
 	if worldedit.pos1[name] == nil then
 		worldedit.player_notify(name, "no position 1 selected")
 		return nil
@@ -583,6 +607,13 @@ minetest.register_chatcommand("/cylinder", {
 })
 
 local check_pyramid = function(name, param)
+	if nil ~= area_protection.areas then
+		worldedit.player_notify(
+			name,
+			"check_pyramid not yet supported with area protection"
+		)
+		return nil
+	end
 	if worldedit.pos1[name] == nil then
 		worldedit.player_notify(name, "no position 1 selected")
 		return nil
@@ -643,6 +674,13 @@ minetest.register_chatcommand("/spiral", {
 		worldedit.player_notify(name, count .. " nodes added")
 	end,
 	function(name, param)
+		if nil ~= area_protection.areas then
+			worldedit.player_notify(
+				name,
+				"/spiral not yet supported with area protection"
+			)
+			return nil
+		end
 		if worldedit.pos1[name] == nil then
 			worldedit.player_notify(name, "no position 1 selected")
 			return nil
@@ -766,6 +804,13 @@ minetest.register_chatcommand("/stack2", {
 			worldedit.stack2(pos1, pos2, {x=x, y=y, z=z}, repetitions,
 				function() worldedit.player_notify(name, count .. " nodes stacked") end)
 		end, function()
+			if nil ~= area_protection.areas then
+				worldedit.player_notify(
+					name,
+					"/stack2 not yet supported with area protection"
+				)
+				return nil
+			end
 			return count
 		end)(name,param) -- more hax --wip: clean this up a little bit
 	end
@@ -791,6 +836,13 @@ minetest.register_chatcommand("/stretch", {
 		worldedit.player_notify(name, count .. " nodes stretched")
 	end,
 	function(name, param)
+		if nil ~= area_protection.areas then
+			worldedit.player_notify(
+				name,
+				"/stretch not yet supported with area protection"
+			)
+			return nil
+		end
 		local found, _, stretchx, stretchy, stretchz = param:find("^(%d+)%s+(%d+)%s+(%d+)$")
 		if found == nil then
 			worldedit.player_notify(name, "invalid usage: " .. param)
@@ -1071,6 +1123,13 @@ minetest.register_chatcommand("/load", {
 	description = "Load nodes from \"(world folder)/schems/<file>[.we[m]]\" with position 1 of the current WorldEdit region as the origin",
 	privs = {worldedit=true},
 	func = function(name, param)
+		if nil ~= area_protection.areas then
+			worldedit.player_notify(
+				name,
+				"/load not yet supported with area protection"
+			)
+			return
+		end
 		local pos = get_position(name)
 		if pos == nil then return end
 
@@ -1187,6 +1246,13 @@ minetest.register_chatcommand("/mtschemplace", {
 	description = "Load nodes from \"(world folder)/schems/<file>.mts\" with position 1 of the current WorldEdit region as the origin",
 	privs = {worldedit=true},
 	func = function(name, param)
+		if nil ~= area_protection.areas then
+			worldedit.player_notify(
+				name,
+				"/mtschemplace not yet supported with area protection"
+			)
+			return
+		end
 		if param == "" then
 			worldedit.player_notify(name, "no filename specified")
 			return

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -515,13 +515,6 @@ minetest.register_chatcommand("/sphere", {
 })
 
 local check_dome = function(name, param)
-	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
-		worldedit.player_notify(
-			name,
-			"check_dome not yet supported with area protection"
-		)
-		return nil
-	end
 	if worldedit.pos1[name] == nil then
 		worldedit.player_notify(name, "no position 1 selected")
 		return nil
@@ -530,6 +523,30 @@ local check_dome = function(name, param)
 	if found == nil then
 		worldedit.player_notify(name, "invalid usage: " .. param)
 		return nil
+	end
+	if nil ~= area_protection.areas then
+		local pos1 = worldedit.pos1[name]
+		local allowed, conflicting = area_protection.areas:canInteractInArea(
+			{
+				x = pos1.x - radius,
+				y = pos1.y,
+				z = pos1.z - radius,
+			},
+			{
+				x = pos1.x + radius,
+				y = pos1.y + radius,
+				z = pos1.z + radius,
+			},
+			name,
+			false
+		)
+		if false == allowed then
+			worldedit.player_notify(
+				name,
+				"dome may conflict with non-owned region " .. conflicting
+			)
+			return nil
+		end
 	end
 	local node = get_node(name, nodename)
 	if not node then return nil end

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -409,7 +409,7 @@ minetest.register_chatcommand("/mix", {
 })
 
 local check_replace = function(name, param)
-	if nil ~= area_protection.areas then
+	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 		worldedit.player_notify(
 			name,
 			"check_replace not yet supported with area protection"
@@ -463,7 +463,7 @@ minetest.register_chatcommand("/replaceinverse", {
 })
 
 local check_sphere = function(name, param)
-	if nil ~= area_protection.areas then
+	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 		worldedit.player_notify(
 			name,
 			"check_sphere not yet supported with area protection"
@@ -505,7 +505,7 @@ minetest.register_chatcommand("/sphere", {
 })
 
 local check_dome = function(name, param)
-	if nil ~= area_protection.areas then
+	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 		worldedit.player_notify(
 			name,
 			"check_dome not yet supported with area protection"
@@ -551,7 +551,7 @@ minetest.register_chatcommand("/dome", {
 })
 
 local check_cylinder = function(name, param)
-	if nil ~= area_protection.areas then
+	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 		worldedit.player_notify(
 			name,
 			"check_cylinder not yet supported with area protection"
@@ -607,7 +607,7 @@ minetest.register_chatcommand("/cylinder", {
 })
 
 local check_pyramid = function(name, param)
-	if nil ~= area_protection.areas then
+	if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 		worldedit.player_notify(
 			name,
 			"check_pyramid not yet supported with area protection"
@@ -674,7 +674,7 @@ minetest.register_chatcommand("/spiral", {
 		worldedit.player_notify(name, count .. " nodes added")
 	end,
 	function(name, param)
-		if nil ~= area_protection.areas then
+		if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 			worldedit.player_notify(
 				name,
 				"/spiral not yet supported with area protection"
@@ -804,7 +804,7 @@ minetest.register_chatcommand("/stack2", {
 			worldedit.stack2(pos1, pos2, {x=x, y=y, z=z}, repetitions,
 				function() worldedit.player_notify(name, count .. " nodes stacked") end)
 		end, function()
-			if nil ~= area_protection.areas then
+			if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 				worldedit.player_notify(
 					name,
 					"/stack2 not yet supported with area protection"
@@ -836,7 +836,7 @@ minetest.register_chatcommand("/stretch", {
 		worldedit.player_notify(name, count .. " nodes stretched")
 	end,
 	function(name, param)
-		if nil ~= area_protection.areas then
+		if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 			worldedit.player_notify(
 				name,
 				"/stretch not yet supported with area protection"
@@ -1123,7 +1123,7 @@ minetest.register_chatcommand("/load", {
 	description = "Load nodes from \"(world folder)/schems/<file>[.we[m]]\" with position 1 of the current WorldEdit region as the origin",
 	privs = {worldedit=true},
 	func = function(name, param)
-		if nil ~= area_protection.areas then
+		if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 			worldedit.player_notify(
 				name,
 				"/load not yet supported with area protection"
@@ -1246,7 +1246,7 @@ minetest.register_chatcommand("/mtschemplace", {
 	description = "Load nodes from \"(world folder)/schems/<file>.mts\" with position 1 of the current WorldEdit region as the origin",
 	privs = {worldedit=true},
 	func = function(name, param)
-		if nil ~= area_protection.areas then
+		if nil ~= area_protection.areas and not minetest.check_player_privs(name, {areas = true}) then
 			worldedit.player_notify(
 				name,
 				"/mtschemplace not yet supported with area protection"

--- a/worldedit_commands/safe.lua
+++ b/worldedit_commands/safe.lua
@@ -1,3 +1,11 @@
+local area_protection = {}
+
+if minetest.get_modpath(
+    "areas"
+) then
+    area_protection.areas = areas
+end
+
 local safe_region_callback = {}
 local safe_region_param = {}
 
@@ -6,6 +14,21 @@ local function check_region(name, param)
 	if pos1 == nil or pos2 == nil then
 		worldedit.player_notify(name, "no region selected")
 		return nil
+	end
+	if nil ~= area_protection.areas then
+		local allowed, conflicting = area_protection.areas:canInteractInArea(
+			pos1,
+			pos2,
+			name,
+			false
+		)
+		if false == allowed then
+			worldedit.player_notify(
+				name,
+				"region conflicts with non-owned region " .. conflicting
+			)
+			return nil
+		end
 	end
 	return worldedit.volume(pos1, pos2)
 end
@@ -62,4 +85,4 @@ minetest.register_chatcommand("/n", {
 })
 
 
-return safe_region, check_region, reset_pending
+return safe_region, check_region, reset_pending, area_protection


### PR DESCRIPTION
This pull request is part of an effort to enable the usage of WorldEdit for less privileged (non-admin) players on a server without risking disruption of the world as a whole.

In this specific case, support for ShadowNinja's area protection mod is added, so worldedit cannot be used to circumvent area protection.

This is still a work in progress, and not all region types are supported yet. So, this pull request is also to enable discussions throughout the further development.