### PR TITLE
Allow to bulk-set param2 of regions

### DIFF
--- a/ChatCommands.md
+++ b/ChatCommands.md
@@ -116,6 +116,10 @@ Set the current WorldEdit region to `<node>`.
     //set Blue Lightstone
     //set dirt with grass
 
+### `//param2 <param2>`
+
+Set the param2 value of all nodes in the current WorldEdit region to `<param2>`.
+
 ### `//mix <node1> ...`
 
 Fill the current WorldEdit region with a random mix of `<node1>`, `...`.

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -27,6 +27,12 @@ Sets a region defined by positions `pos1` and `pos2` to `node_name`. To clear a 
 
 Returns the number of nodes set.
 
+### `count = worldedit.set_param2(pos1, pos2, param2)`
+
+Sets the param2 values of all nodes in a region defined by positions `pos1` and `pos2` to `param2`.
+
+Returns the number of nodes set.
+
 ### count = worldedit.replace(pos1, pos2, searchnode, replacenode)
 
 Replaces all instances of `searchnode` with `replacenode` in a region defined by positions `pos1` and `pos2`.

--- a/worldedit/common.lua
+++ b/worldedit/common.lua
@@ -109,5 +109,6 @@ function mh.finish(manip, data)
 	-- Update map
 	manip:set_data(data)
 	manip:write_to_map()
+	manip:update_map()
 end
 

--- a/worldedit/common.lua
+++ b/worldedit/common.lua
@@ -109,6 +109,5 @@ function mh.finish(manip, data)
 	-- Update map
 	manip:set_data(data)
 	manip:write_to_map()
-	manip:update_map()
 end
 

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -57,7 +57,6 @@ function worldedit.set_param2(pos1, pos2, param2)
 	-- Update map
 	manip:set_param2_data(param2_data)
 	manip:write_to_map()
-	manip:update_map()
 
 	return worldedit.volume(pos1, pos2)
 end
@@ -600,7 +599,6 @@ function worldedit.fixlight(pos1, pos2)
 
 	local vmanip = minetest.get_voxel_manip(pos1, pos2)
 	vmanip:write_to_map()
-	vmanip:update_map() -- this updates the lighting
 
 	return worldedit.volume(pos1, pos2)
 end

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -47,7 +47,7 @@ function worldedit.set_param2(pos1, pos2, param2)
 	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 
 	local manip, area = mh.init(pos1, pos2)
-	local param2_data = {}
+	local param2_data = manip:get_param2_data()
 
 	-- Set param2 for every node
 	for i in area:iterp(pos1, pos2) do

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -57,6 +57,7 @@ function worldedit.set_param2(pos1, pos2, param2)
 	-- Update map
 	manip:set_param2_data(param2_data)
 	manip:write_to_map()
+	manip:update_map()
 
 	return worldedit.volume(pos1, pos2)
 end
@@ -599,6 +600,7 @@ function worldedit.fixlight(pos1, pos2)
 
 	local vmanip = minetest.get_voxel_manip(pos1, pos2)
 	vmanip:write_to_map()
+	vmanip:update_map() -- this updates the lighting
 
 	return worldedit.volume(pos1, pos2)
 end

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -38,6 +38,29 @@ function worldedit.set(pos1, pos2, node_names)
 	return worldedit.volume(pos1, pos2)
 end
 
+--- Sets param2 of a region.
+-- @param pos1
+-- @param pos2
+-- @param param2 Value of param2 to set
+-- @return The number of nodes set.
+function worldedit.set_param2(pos1, pos2, param2)
+	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+
+	local manip, area = mh.init(pos1, pos2)
+	local param2_data = {}
+
+	-- Set param2 for every node
+	for i in area:iterp(pos1, pos2) do
+		param2_data[i] = param2
+	end
+
+	-- Update map
+	manip:set_param2_data(param2_data)
+	manip:write_to_map()
+	manip:update_map()
+
+	return worldedit.volume(pos1, pos2)
+end
 
 --- Replaces all instances of `search_node` with `replace_node` in a region.
 -- When `inverse` is `true`, replaces all instances that are NOT `search_node`.

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -402,7 +402,7 @@ minetest.register_chatcommand("/param2", {
 		end
 
 		local count = worldedit.set_param2(worldedit.pos1[name], worldedit.pos2[name], param2)
-		worldedit.player_notify(name, count .. " nodes set")
+		worldedit.player_notify(name, count .. " nodes altered")
 	end, check_region),
 })
 

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -387,6 +387,25 @@ minetest.register_chatcommand("/set", {
 	end, check_region),
 })
 
+minetest.register_chatcommand("/param2", {
+	params = "<param2>",
+	description = "Set param2 of all nodes in the current WorldEdit region to <param2>",
+	privs = {worldedit=true},
+	func = safe_region(function(name, param)
+		local param2 = tonumber(param)
+		if not param2 then
+			worldedit.player_notify(name, "Invalid or missing param2 argument")
+			return
+		elseif param2 < 0 or param2 > 255 then
+			worldedit.player_notify(name, "Param2 is out of range (must be between 0 and 255 inclusive)!")
+			return
+		end
+
+		local count = worldedit.set_param2(worldedit.pos1[name], worldedit.pos2[name], param2)
+		worldedit.player_notify(name, count .. " nodes set")
+	end, check_region),
+})
+
 minetest.register_chatcommand("/mix", {
 	params = "<node1> ...",
 	description = "Fill the current WorldEdit region with a random mix of <node1>, ...",


### PR DESCRIPTION
This adds a command `/param2` and a function `worldedit.set_param2` which allow to bulk-set the `param2` value of an entire region.

The nodes appearance is updated immediately. E.g. if a node with `facedir` gets its `param2` changed using this method, it will immediately rotate accordingly.

API docs are updated accordingly.

Use case: Creating and saving tree schematics in MTG. Here, you must force the `param2` of the leaves to be 0. Otherwise, leaves with `param2=1` will not have leafdecay which is not what you want for normal trees.