### PR TITLE
Fix //load with 0 nodes

### DIFF
--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -227,6 +227,7 @@ end
 function worldedit.deserialize(origin_pos, value)
 	local nodes = load_schematic(value)
 	if not nodes then return nil end
+	if #nodes == 0 then return #nodes end
 
 	local pos1, pos2 = worldedit.allocate_with_nodes(origin_pos, nodes)
 	worldedit.keep_loaded(pos1, pos2)


### PR DESCRIPTION
With the WorldEdit version of 15.06.2019 you can reproduce the bug by:

//1
//2
//save

Between //1 and //2 mustn't be a node

And then load the saved area back
//load

Now there is a crash with the following error:

2019-06-15 16:25:55: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'worldedit_commands' in callback on_chat_message(): Invalid float vector dimension range 'x' (expected -2.14748e+006 < x < 2.14748e+006 got inf).
2019-06-15 16:25:55: ERROR[Main]: stack traceback:
2019-06-15 16:25:55: ERROR[Main]: 	[C]: in function 'read_from_map'
2019-06-15 16:25:55: ERROR[Main]: 	...\..\worlds\Test\worldmods\WorldEdit\worldedit/common.lua:50: in function 'keep_loaded'
2019-06-15 16:25:55: ERROR[Main]: 	...lds\Test\worldmods\WorldEdit\worldedit/serialization.lua:233: in function 'deserialize'
2019-06-15 16:25:55: ERROR[Main]: 	...lds\Test\worldmods\WorldEdit\worldedit_commands\init.lua:1224: in function 'func'
2019-06-15 16:25:55: ERROR[Main]: 	...\Documents\Minetest\bin\..\builtin\game\chatcommands.lua:30: in function <...\Documents\Minetest\bin\..\builtin\game\chatcommands.lua:9>
2019-06-15 16:25:55: ERROR[Main]: 	...\Ich\Documents\Minetest\bin\..\builtin\game\register.lua:412: in function <...\Ich\Documents\Minetest\bin\..\builtin\game\register.lua:392>

That's because of the function worldedit.allocate_with_nodes
If the table is empty, the for loop won't run and the function will give back math.huge

My pull request fixes this issue. Normally there's not a problem, because you won't save empty areas, but if you use the worldedit function worldedit.deserialize, then there is this problem, because otherwise you need to check first if the area is empty. Would be nicer if WorldEdit does this.