### PR TITLE
Replace deprecated functions with newer ones

### DIFF
--- a/modpack.conf
+++ b/modpack.conf
@@ -1,0 +1,2 @@
+name = Minetest-WorldEdit
+description = WorldEdit is an in-game world editor. Use it to repair griefing, or just create awesome buildings in seconds.

--- a/worldedit/cuboid.lua
+++ b/worldedit/cuboid.lua
@@ -149,7 +149,7 @@ end
 
 -- Return the marker that is closest to the player
 worldedit.marker_get_closest_to_player = function(name)
-	local playerpos = minetest.get_player_by_name(name):getpos()
+	local playerpos = minetest.get_player_by_name(name):get_pos()
 	local dist1 = vector.distance(playerpos, worldedit.pos1[name])
 	local dist2 = vector.distance(playerpos, worldedit.pos2[name])
 	

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -638,7 +638,7 @@ function worldedit.clear_objects(pos1, pos2)
 		-- Avoid players and WorldEdit entities
 		if not obj:is_player() and (not entity or
 				not entity.name:find("^worldedit:")) then
-			local pos = obj:getpos()
+			local pos = obj:get_pos()
 			if pos.x >= pos1x and pos.x <= pos2x and
 					pos.y >= pos1y and pos.y <= pos2y and
 					pos.z >= pos1z and pos.z <= pos2z then

--- a/worldedit_brush/mod.conf
+++ b/worldedit_brush/mod.conf
@@ -1,0 +1,2 @@
+name = worldedit_brush
+depends = worldedit, worldedit_commands

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -257,7 +257,7 @@ minetest.register_chatcommand("/pos1", {
 	description = "Set WorldEdit region position 1 to the player's location",
 	privs = {worldedit=true},
 	func = function(name, param)
-		local pos = minetest.get_player_by_name(name):getpos()
+		local pos = minetest.get_player_by_name(name):get_pos()
 		pos.x, pos.y, pos.z = math.floor(pos.x + 0.5), math.floor(pos.y + 0.5), math.floor(pos.z + 0.5)
 		worldedit.pos1[name] = pos
 		worldedit.mark_pos1(name)
@@ -270,7 +270,7 @@ minetest.register_chatcommand("/pos2", {
 	description = "Set WorldEdit region position 2 to the player's location",
 	privs = {worldedit=true},
 	func = function(name, param)
-		local pos = minetest.get_player_by_name(name):getpos()
+		local pos = minetest.get_player_by_name(name):get_pos()
 		pos.x, pos.y, pos.z = math.floor(pos.x + 0.5), math.floor(pos.y + 0.5), math.floor(pos.z + 0.5)
 		worldedit.pos2[name] = pos
 		worldedit.mark_pos2(name)

--- a/worldedit_commands/mod.conf
+++ b/worldedit_commands/mod.conf
@@ -1,0 +1,2 @@
+name = worldedit_commands
+depends = worldedit

--- a/worldedit_gui/mod.conf
+++ b/worldedit_gui/mod.conf
@@ -1,0 +1,3 @@
+name = worldedit_gui
+depends = worldedit, worldedit_commands
+optional_depends = unified_inventory, inventory_plus, sfinv, creative, smart_inventory

--- a/worldedit_shortcommands/mod.conf
+++ b/worldedit_shortcommands/mod.conf
@@ -1,0 +1,2 @@
+name = worldedit_shortcommands
+depends = worldedit_commands


### PR DESCRIPTION
This PR creates compatibility with MT/MTG 5.0.0+.
However, this PR breaks compatibility with the 0.4-series.

Tested with MT/MTG 5.0.1 and everything works fine (I found no bugs/errors).
If you find any bug/error/typo (on my PR), please let me know, we can work together to fix it.
Probably a new release should be made for MT/MTG 5.0.0+ and WE 1.2 will be the latest release supporting the 0.4-series.