### PR TITLE
Add .luacheckrc and do some style-related changes

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -1,0 +1,15 @@
+on: [push, pull_request]
+name: Check & Release
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: apt
+      run: sudo apt-get install -y luarocks
+    - name: luacheck install
+      run: luarocks install --local luacheck
+    - name: luacheck run
+      run: $HOME/.luarocks/bin/luacheck ./

--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,7 @@
+read_globals = {"minetest", "vector", "VoxelArea", "ItemStack",
+	"table",
+	"unified_inventory", "sfinv", "smart_inventory", "inventory_plus"
+}
+globals = {"worldedit"}
+-- Ignore these style errors until someone decides to fix them
+ignore = {"411", "412", "421", "422", "431", "432", "631"}

--- a/worldedit/compatibility.lua
+++ b/worldedit/compatibility.lua
@@ -24,11 +24,14 @@ function worldedit.metasave(pos1, pos2, filename)
 	return count
 end
 
-function worldedit.metaload(originpos, filename)
+function worldedit.metaload(originpos, file_name)
 	deprecated("load")
-	filename = minetest.get_worldpath() .. "/schems/" .. file .. ".wem"
-	local file, err = io.open(filename, "wb")
-	if err then return 0 end
+	local file_path = minetest.get_worldpath() ..
+		"/schems/" .. file_name .. ".wem"
+	local file, err = io.open(file_path, "wb")
+	if err then
+		return 0
+	end
 	local data = file:read("*a")
 	return worldedit.deserialize(originpos, data)
 end

--- a/worldedit/cuboid.lua
+++ b/worldedit/cuboid.lua
@@ -2,16 +2,16 @@
 worldedit.cuboid_volumetric_expand = function(name, amount)
 	local pos1 = worldedit.pos1[name]
 	local pos2 = worldedit.pos2[name]
-	
+
 	if pos1 == nil or pos2 == nil then
 		return false, "Undefined cuboid"
 	end
-	
+
 	local delta1 = vector.new()
 	local delta2 = vector.new()
 	local delta_dir1
 	local delta_dir2
-	
+
 	delta1 = vector.add(delta1, amount)
 	delta2 = vector.add(delta2, amount)
 	delta_dir1, delta_dir2 = worldedit.get_expansion_directions(pos1, pos2)
@@ -19,7 +19,7 @@ worldedit.cuboid_volumetric_expand = function(name, amount)
 	delta2 = vector.multiply(delta2, delta_dir2)
 	worldedit.pos1[name] = vector.add(pos1, delta1)
 	worldedit.pos2[name] = vector.add(pos2, delta2)
-	
+
 	return true
 end
 
@@ -28,18 +28,18 @@ end
 worldedit.cuboid_linear_expand = function(name, axis, direction, amount)
 	local pos1 = worldedit.pos1[name]
 	local pos2 = worldedit.pos2[name]
-	
+
 	if pos1 == nil or pos2 == nil then
 		return false, "undefined cuboid"
 	end
-	
+
 	if direction ~= 1 and direction ~= -1 then
 		return false, "invalid marker"
 	end
-	
+
 	local marker = worldedit.marker_get_closest_to_axis(name, axis, direction)
 	local deltavect = vector.new()
-	
+
 	if axis == 'x' then
 		deltavect.x = amount * direction
 	elseif axis == 'y' then
@@ -49,7 +49,7 @@ worldedit.cuboid_linear_expand = function(name, axis, direction, amount)
 	else
 		return false, "invalid axis"
 	end
-	
+
 	worldedit.marker_move(name, marker, deltavect)
 	return true
 end
@@ -59,11 +59,11 @@ end
 worldedit.cuboid_shift = function(name, axis, amount)
 	local pos1 = worldedit.pos1[name]
 	local pos2 = worldedit.pos2[name]
-	
+
 	if pos1 == nil or pos2 == nil then
 		return false, "undefined cuboid"
 	end
-	
+
 	if axis == 'x' then
 		worldedit.pos1[name].x = pos1.x + amount
 		worldedit.pos2[name].x = pos2.x + amount
@@ -76,7 +76,7 @@ worldedit.cuboid_shift = function(name, axis, amount)
 	else
 		return false, "invalid axis"
 	end
-	
+
 	return true
 end
 
@@ -86,7 +86,7 @@ worldedit.marker_move = function(name, marker, deltavector)
 	if marker ~= 1 and marker ~= 2 then
 		return false
 	end
-	
+
 	if marker == 1 then
 		local pos = worldedit.pos1[name]
 		worldedit.pos1[name] = vector.add(deltavector, pos)
@@ -94,7 +94,7 @@ worldedit.marker_move = function(name, marker, deltavector)
 		local pos = worldedit.pos2[name]
 		worldedit.pos2[name] = vector.add(deltavector, pos)
 	end
-	
+
 	return true
 end
 
@@ -137,7 +137,7 @@ worldedit.marker_get_closest_to_player = function(name)
 	local playerpos = minetest.get_player_by_name(name):get_pos()
 	local dist1 = vector.distance(playerpos, worldedit.pos1[name])
 	local dist2 = vector.distance(playerpos, worldedit.pos2[name])
-	
+
 	if dist1 < dist2 then
 		return 1
 	else
@@ -150,7 +150,7 @@ end
 worldedit.marker_get_closest_to_axis = function(name, axis, direction)
 	local pos1 = vector.new()
 	local pos2 = vector.new()
-	
+
 	if direction ~= 1 and direction ~= -1 then
 		return nil
 	end
@@ -185,20 +185,20 @@ worldedit.marker_get_closest_to_axis = function(name, axis, direction)
 end
 
 
--- Translates up, down, left, right, front, back to their corresponding axes and 
+-- Translates up, down, left, right, front, back to their corresponding axes and
 -- directions according to faced direction
 worldedit.translate_direction = function(name, direction)
 	local axis, dir = worldedit.player_axis(name)
 	local resaxis, resdir
-	
+
 	if direction == "up" then
 		return 'y', 1
 	end
-	
+
 	if direction == "down" then
 		return 'y', -1
 	end
-	
+
 	if direction == "front" then
 		if axis == "y" then
 			resaxis = nil
@@ -208,7 +208,7 @@ worldedit.translate_direction = function(name, direction)
 			resdir = dir
 		end
 	end
-	
+
 	if direction == "back" then
 		if axis == "y" then
 			resaxis = nil
@@ -218,7 +218,7 @@ worldedit.translate_direction = function(name, direction)
 			resdir = -dir
 		end
 	end
-	
+
 	if direction == "left" then
 		if axis == 'x' then
 			resaxis = 'z'
@@ -228,7 +228,7 @@ worldedit.translate_direction = function(name, direction)
 			resdir = -dir
 		end
 	end
-	
+
 	if direction == "right" then
 		if axis == 'x' then
 			resaxis = 'z'
@@ -238,6 +238,6 @@ worldedit.translate_direction = function(name, direction)
 			resdir = dir
 		end
 	end
-	
+
 	return resaxis, resdir
 end

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -217,8 +217,6 @@ function worldedit.copy2(pos1, pos2, off, meta_backwards)
 	dst_manip:set_param2_data(dst_data)
 
 	mh.finish(dst_manip)
-	src_data = nil
-	dst_data = nil
 
 	-- Copy metadata
 	local get_meta = minetest.get_meta

--- a/worldedit/primitives.lua
+++ b/worldedit/primitives.lua
@@ -278,7 +278,7 @@ function worldedit.spiral(pos, length, height, spacer, node_name)
 	-- Add first column
 	local count = height
 	local column = i
-	for y = 1, height do
+	for _ = 1, height do
 		data[column] = node_id
 		column = column + stride.y
 	end
@@ -296,12 +296,12 @@ function worldedit.spiral(pos, length, height, spacer, node_name)
 			segment_length = segment_length + spacer
 		end
 		-- Fill segment
-		for index = 1, segment_length do
+		for _ = 1, segment_length do
 			-- Move along the direction of the segment
 			i = i + stride_axis * sign
 			local column = i
 			-- Add column
-			for y = 1, height do
+			for _ = 1, height do
 				data[column] = node_id
 				column = column + stride.y
 			end
@@ -312,11 +312,11 @@ function worldedit.spiral(pos, length, height, spacer, node_name)
 
 	-- Add shorter final segment
 	sign = -sign
-	for index = 1, segment_length do
+	for _ = 1, segment_length do
 		i = i + stride_axis * sign
 		local column = i
 		-- Add column
-		for y = 1, height do
+		for _ = 1, height do
 			data[column] = node_id
 			column = column + stride.y
 		end

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -148,7 +148,7 @@ end
 --- Loads the schematic in `value` into a node list in the latest format.
 -- @return A node list in the latest format, or nil on failure.
 local function load_schematic(value)
-	local version, header, content = worldedit.read_header(value)
+	local version, _, content = worldedit.read_header(value)
 	local nodes = {}
 	if version == 1 or version == 2 then -- Original flat table format
 		local tables = minetest.deserialize(content, true)
@@ -240,7 +240,6 @@ function worldedit.deserialize(origin_pos, value)
 	worldedit.keep_loaded(pos1, pos2)
 
 	local origin_x, origin_y, origin_z = origin_pos.x, origin_pos.y, origin_pos.z
-	local count = 0
 	local add_node, get_meta = minetest.add_node, minetest.get_meta
 	for _, entry in ipairs(nodes) do
 		entry.x, entry.y, entry.z = origin_x + entry.x, origin_y + entry.y, origin_z + entry.z

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -165,7 +165,7 @@ local function load_schematic(value)
 		nodes = tables[1]
 
 		if version == 1 then --original flat table format
-			for i, entry in ipairs(nodes) do
+			for _, entry in ipairs(nodes) do
 				local pos = entry[1]
 				entry.x, entry.y, entry.z = pos.x, pos.y, pos.z
 				entry[1] = nil
@@ -214,7 +214,7 @@ function worldedit.allocate_with_nodes(origin_pos, nodes)
 	local pos1x, pos1y, pos1z = huge, huge, huge
 	local pos2x, pos2y, pos2z = -huge, -huge, -huge
 	local origin_x, origin_y, origin_z = origin_pos.x, origin_pos.y, origin_pos.z
-	for i, entry in ipairs(nodes) do
+	for _, entry in ipairs(nodes) do
 		local x, y, z = origin_x + entry.x, origin_y + entry.y, origin_z + entry.z
 		if x < pos1x then pos1x = x end
 		if y < pos1y then pos1y = y end
@@ -242,7 +242,7 @@ function worldedit.deserialize(origin_pos, value)
 	local origin_x, origin_y, origin_z = origin_pos.x, origin_pos.y, origin_pos.z
 	local count = 0
 	local add_node, get_meta = minetest.add_node, minetest.get_meta
-	for i, entry in ipairs(nodes) do
+	for _, entry in ipairs(nodes) do
 		entry.x, entry.y, entry.z = origin_x + entry.x, origin_y + entry.y, origin_z + entry.z
 		-- Entry acts as both position and node
 		add_node(entry, entry)

--- a/worldedit_brush/init.lua
+++ b/worldedit_brush/init.lua
@@ -65,7 +65,7 @@ minetest.register_tool(":worldedit:brush", {
 	inventory_image = "worldedit_brush.png",
 	stack_max = 1, -- no need to stack these (metadata prevents this anyway)
 	range = 0,
-	on_use = function(itemstack, placer, pointed_thing)
+	on_use = function(itemstack, placer)
 		brush_on_use(itemstack, placer)
 		return itemstack -- nothing consumed, nothing changed
 	end,

--- a/worldedit_commands/cuboid.lua
+++ b/worldedit_commands/cuboid.lua
@@ -239,7 +239,7 @@ worldedit.register_command("cubeapply", {
 		end
 		return true, sidex, sidey, sidez, cmd, parsed
 	end,
-	nodes_needed = function(name, sidex, sidey, sidez, cmd, parsed)
+	nodes_needed = function(_, sidex, sidey, sidez)
 		-- its not possible to defer to the target command at this point
 		return sidex * sidey * sidez
 	end,

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -64,7 +64,7 @@ end
 -- def = {
 --     privs = {}, -- Privileges needed
 --     params = "", -- Human readable parameter list (optional)
---         -- setting params = "" will automatically provide a parse() if not given 
+--         -- setting params = "" will automatically provide a parse() if not given
 --     description = "", -- Description
 --     require_pos = 0, -- Number of positions required to be set (optional)
 --     parse = function(param)
@@ -844,7 +844,7 @@ local check_pyramid = function(param)
 	end
 	return true, axis, tonumber(height), node
 end
-     
+
 worldedit.register_command("hollowpyramid", {
 	params = "x/y/z/? <height> <node>",
 	description = "Add hollow pyramid centered at WorldEdit position 1 along the given axis with height <height>, composed of <node>",

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -45,14 +45,14 @@ local function chatcommand_handler(cmd_name, name, param)
 	if def.nodes_needed then
 		local count = def.nodes_needed(name, unpack(parsed))
 		safe_region(name, count, function()
-			local success, msg = def.func(name, unpack(parsed))
+			local _, msg = def.func(name, unpack(parsed))
 			if msg then
 				minetest.chat_send_player(name, msg)
 			end
 		end)
 	else
 		-- no "safe region" check
-		local success, msg = def.func(name, unpack(parsed))
+		local _, msg = def.func(name, unpack(parsed))
 		if msg then
 			minetest.chat_send_player(name, msg)
 		end
@@ -263,7 +263,6 @@ worldedit.register_command("help", {
 			return false, "You are not allowed to use any WorldEdit commands."
 		end
 		if param == "" then
-			local msg = ""
 			local cmds = {}
 			for cmd, def in pairs(worldedit.registered_commands) do
 				if minetest.check_player_privs(name, def.privs) then
@@ -1344,7 +1343,7 @@ worldedit.register_command("restore", {
 })
 
 local function detect_misaligned_schematic(name, pos1, pos2)
-	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+	pos1 = worldedit.sort_pos(pos1, pos2)
 	-- Check that allocate/save can position the schematic correctly
 	-- The expected behaviour is that the (0,0,0) corner of the schematic stays
 	-- sat pos1, this only works when the minimum position is actually present

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -88,7 +88,7 @@ function worldedit.register_command(name, def)
 	def.require_pos = def.require_pos or 0
 	assert(def.require_pos >= 0 and def.require_pos < 3)
 	if def.params == "" and not def.parse then
-		def.parse = function(param) return true end
+		def.parse = function() return true end
 	else
 		assert(def.parse)
 	end
@@ -470,7 +470,7 @@ worldedit.register_command("fixedpos", {
 	end,
 })
 
-minetest.register_on_punchnode(function(pos, node, puncher)
+minetest.register_on_punchnode(function(pos, _, puncher)
 	local name = puncher:get_player_name()
 	if name ~= "" and worldedit.set_pos[name] ~= nil then --currently setting position
 		if worldedit.set_pos[name] == "pos1" then --setting position 1
@@ -579,7 +579,7 @@ worldedit.register_command("mix", {
 		for nodename in param:gmatch("[^%s]+") do
 			if tonumber(nodename) ~= nil and #nodes > 0 then
 				local last_node = nodes[#nodes]
-				for i = 1, tonumber(nodename) do
+				for _ = 1, tonumber(nodename) do
 					nodes[#nodes + 1] = last_node
 				end
 			else
@@ -665,7 +665,7 @@ worldedit.register_command("hollowcube", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_cube,
-	nodes_needed = function(name, w, h, l, node)
+	nodes_needed = function(_, w, h, l)
 		return w * h * l
 	end,
 	func = function(name, w, h, l, node)
@@ -680,7 +680,7 @@ worldedit.register_command("cube", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_cube,
-	nodes_needed = function(name, w, h, l, node)
+	nodes_needed = function(_, w, h, l)
 		return w * h * l
 	end,
 	func = function(name, w, h, l, node)
@@ -707,7 +707,7 @@ worldedit.register_command("hollowsphere", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_sphere,
-	nodes_needed = function(name, radius, node)
+	nodes_needed = function(_, radius)
 		return math.ceil((4 * math.pi * (radius ^ 3)) / 3) --volume of sphere
 	end,
 	func = function(name, radius, node)
@@ -722,7 +722,7 @@ worldedit.register_command("sphere", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_sphere,
-	nodes_needed = function(name, radius, node)
+	nodes_needed = function(_, radius)
 		return math.ceil((4 * math.pi * (radius ^ 3)) / 3) --volume of sphere
 	end,
 	func = function(name, radius, node)
@@ -749,7 +749,7 @@ worldedit.register_command("hollowdome", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_dome,
-	nodes_needed = function(name, radius, node)
+	nodes_needed = function(_, radius)
 		return math.ceil((2 * math.pi * (radius ^ 3)) / 3) --volume of dome
 	end,
 	func = function(name, radius, node)
@@ -764,7 +764,7 @@ worldedit.register_command("dome", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_dome,
-	nodes_needed = function(name, radius, node)
+	nodes_needed = function(_, radius)
 		return math.ceil((2 * math.pi * (radius ^ 3)) / 3) --volume of dome
 	end,
 	func = function(name, radius, node)
@@ -797,7 +797,7 @@ worldedit.register_command("hollowcylinder", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_cylinder,
-	nodes_needed = function(name, axis, length, radius1, radius2, node)
+	nodes_needed = function(_, _, length, radius1, radius2)
 		local radius = math.max(radius1, radius2)
 		return math.ceil(math.pi * (radius ^ 2) * length)
 	end,
@@ -818,7 +818,7 @@ worldedit.register_command("cylinder", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_cylinder,
-	nodes_needed = function(name, axis, length, radius1, radius2, node)
+	nodes_needed = function(_, _, length, radius1, radius2)
 		local radius = math.max(radius1, radius2)
 		return math.ceil(math.pi * (radius ^ 2) * length)
 	end,
@@ -851,7 +851,7 @@ worldedit.register_command("hollowpyramid", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_pyramid,
-	nodes_needed = function(name, axis, height, node)
+	nodes_needed = function(_, _, height)
 		return math.ceil(((height * 2 + 1) ^ 2) * height / 3)
 	end,
 	func = function(name, axis, height, node)
@@ -871,7 +871,7 @@ worldedit.register_command("pyramid", {
 	privs = {worldedit=true},
 	require_pos = 1,
 	parse = check_pyramid,
-	nodes_needed = function(name, axis, height, node)
+	nodes_needed = function(_, _, height)
 		return math.ceil(((height * 2 + 1) ^ 2) * height / 3)
 	end,
 	func = function(name, axis, height, node)
@@ -901,7 +901,7 @@ worldedit.register_command("spiral", {
 		end
 		return true, tonumber(length), tonumber(height), tonumber(space), node
 	end,
-	nodes_needed = function(name, length, height, space, node)
+	nodes_needed = function(_, length, height, space)
 		return (length + space) * height -- TODO: this is not the upper bound
 	end,
 	func = function(name, length, height, space, node)
@@ -922,7 +922,7 @@ worldedit.register_command("copy", {
 		end
 		return true, axis, tonumber(amount)
 	end,
-	nodes_needed = function(name, axis, amount)
+	nodes_needed = function(name)
 		return check_region(name) * 2
 	end,
 	func = function(name, axis, amount)
@@ -949,7 +949,7 @@ worldedit.register_command("move", {
 		end
 		return true, axis, tonumber(amount)
 	end,
-	nodes_needed = function(name, axis, amount)
+	nodes_needed = function(name)
 		return check_region(name) * 2
 	end,
 	func = function(name, axis, amount)
@@ -981,7 +981,7 @@ worldedit.register_command("stack", {
 		end
 		return true, axis, tonumber(repetitions)
 	end,
-	nodes_needed = function(name, axis, repetitions)
+	nodes_needed = function(name, _, repetitions)
 		return check_region(name) * math.abs(repetitions)
 	end,
 	func = function(name, axis, repetitions)
@@ -1016,7 +1016,7 @@ worldedit.register_command("stack2", {
 
 		return true, tonumber(repetitions), {x=tonumber(x), y=tonumber(y), z=tonumber(z)}
 	end,
-	nodes_needed = function(name, repetitions, offset)
+	nodes_needed = function(name, repetitions)
 		return check_region(name) * repetitions
 	end,
 	func = function(name, repetitions, offset)
@@ -1480,7 +1480,7 @@ worldedit.register_command("load", {
 			minetest.get_worldpath() .. "/schems/" .. param .. ".wem",
 		}
 		local file, err
-		for index, path in ipairs(testpaths) do
+		for _, path in ipairs(testpaths) do
 			file, err = io.open(path, "rb")
 			if not err then
 				break
@@ -1633,7 +1633,7 @@ worldedit.register_command("mtschemprob", {
 			if problist == nil then
 				return
 			end
-			for k,v in pairs(problist) do
+			for _,v in pairs(problist) do
 				local prob = math.floor(((v.prob / 256) * 100) * 100 + 0.5) / 100
 				text = text .. minetest.pos_to_string(v.pos) .. ": " .. prob .. "% | "
 			end

--- a/worldedit_commands/mark.lua
+++ b/worldedit_commands/mark.lua
@@ -6,7 +6,7 @@ local init_sentinel = "new" .. tostring(math.random(99999))
 
 --marks worldedit region position 1
 worldedit.mark_pos1 = function(name, region_too)
-	local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]
+	local pos1 = worldedit.pos1[name]
 
 	if worldedit.marker1[name] ~= nil then --marker already exists
 		worldedit.marker1[name]:remove() --remove marker
@@ -30,7 +30,7 @@ end
 
 --marks worldedit region position 2
 worldedit.mark_pos2 = function(name, region_too)
-	local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]
+	local pos2 = worldedit.pos2[name]
 
 	if worldedit.marker2[name] ~= nil then --marker already exists
 		worldedit.marker2[name]:remove() --remove marker

--- a/worldedit_commands/mark.lua
+++ b/worldedit_commands/mark.lua
@@ -134,17 +134,17 @@ minetest.register_entity(":worldedit:pos1", {
 		physical = false,
 		static_save = false,
 	},
-	on_activate = function(self, staticdata, dtime_s)
+	on_activate = function(self, staticdata)
 		if staticdata ~= init_sentinel then
 			-- we were loaded from before static_save = false was added
 			self.object:remove()
 		end
 	end,
-	on_punch = function(self, hitter)
+	on_punch = function(self)
 		self.object:remove()
 		worldedit.marker1[self.player_name] = nil
 	end,
-	on_blast = function(self, damage)
+	on_blast = function()
 		return false, false, {} -- don't damage or knockback
 	end,
 })
@@ -160,17 +160,17 @@ minetest.register_entity(":worldedit:pos2", {
 		physical = false,
 		static_save = false,
 	},
-	on_activate = function(self, staticdata, dtime_s)
+	on_activate = function(self, staticdata)
 		if staticdata ~= init_sentinel then
 			-- we were loaded from before static_save = false was added
 			self.object:remove()
 		end
 	end,
-	on_punch = function(self, hitter)
+	on_punch = function(self)
 		self.object:remove()
 		worldedit.marker2[self.player_name] = nil
 	end,
-	on_blast = function(self, damage)
+	on_blast = function()
 		return false, false, {} -- don't damage or knockback
 	end,
 })
@@ -183,13 +183,13 @@ minetest.register_entity(":worldedit:region_cube", {
 		physical = false,
 		static_save = false,
 	},
-	on_activate = function(self, staticdata, dtime_s)
+	on_activate = function(self, staticdata)
 		if staticdata ~= init_sentinel then
 			-- we were loaded from before static_save = false was added
 			self.object:remove()
 		end
 	end,
-	on_punch = function(self, hitter)
+	on_punch = function(self)
 		local markers = worldedit.marker_region[self.player_name]
 		if not markers then
 			return
@@ -199,7 +199,7 @@ minetest.register_entity(":worldedit:region_cube", {
 		end
 		worldedit.marker_region[self.player_name] = nil
 	end,
-	on_blast = function(self, damage)
+	on_blast = function()
 		return false, false, {} -- don't damage or knockback
 	end,
 })

--- a/worldedit_commands/wand.lua
+++ b/worldedit_commands/wand.lua
@@ -14,7 +14,7 @@ minetest.register_tool(":worldedit:wand", {
 	stack_max = 1, -- there is no need to have more than one
 	liquids_pointable = true, -- ground with only water on can be selected as well
 
-	on_use = function(itemstack, placer, pointed_thing)
+	on_use = function(_, placer, pointed_thing)
 		if placer == nil or pointed_thing == nil then return end
 		local name = placer:get_player_name()
 		if pointed_thing.type == "node" then

--- a/worldedit_gui/functionality.lua
+++ b/worldedit_gui/functionality.lua
@@ -39,7 +39,7 @@ setmetatable(angle_values, {__index = function () return 90 end})
 -- given multiple sets of privileges, produces a single set of privs that would have the same effect as requiring all of them at the same time
 local combine_privs = function(...)
 	local result = {}
-	for i, privs in ipairs({...}) do
+	for _, privs in ipairs({...}) do
 		for name, value in pairs(privs) do
 			if result[name] ~= nil and result[name] ~= value then --the priv must be both true and false, which can never happen
 				return {__fake_priv_that_nobody_has__=true} --privilege table that can never be satisfied

--- a/worldedit_gui/init.lua
+++ b/worldedit_gui/init.lua
@@ -4,10 +4,10 @@ worldedit = worldedit or {}
 Example:
 
     worldedit.register_gui_function("worldedit_gui_hollow_cylinder", {
-    	name = "Make Hollow Cylinder",
-    	privs = {worldedit=true},
-    	get_formspec = function(name) return "some formspec here" end,
-    	on_select = function(name) print(name .. " clicked the button!") end,
+		name = "Make Hollow Cylinder",
+		privs = {worldedit=true},
+		get_formspec = function(name) return "some formspec here" end,
+		on_select = function(name) print(name .. " clicked the button!") end,
     })
 
 Use `nil` for the `options` parameter to unregister the function associated with the given identifier.
@@ -35,7 +35,7 @@ end
 Example:
 
     worldedit.register_gui_handler("worldedit_gui_hollow_cylinder", function(name, fields)
-    	print(minetest.serialize(fields))
+		print(minetest.serialize(fields))
     end)
 ]]
 

--- a/worldedit_gui/init.lua
+++ b/worldedit_gui/init.lua
@@ -41,7 +41,7 @@ Example:
 
 worldedit.register_gui_handler = function(identifier, handler)
 	local enabled = true
-	minetest.register_on_player_receive_fields(function(player, formname, fields)
+	minetest.register_on_player_receive_fields(function(player, _, fields)
 		if not enabled then return false end
 		enabled = false
 		minetest.after(0.2, function() enabled = true end)
@@ -85,7 +85,7 @@ if minetest.global_exists("unified_inventory") then -- unified inventory install
 		end,
 	})
 
-	minetest.register_on_player_receive_fields(function(player, formname, fields)
+	minetest.register_on_player_receive_fields(function(player, _, fields)
 		local name = player:get_player_name()
 		if fields.worldedit_gui then --main page
 			worldedit.show_page(name, "worldedit_gui")
@@ -116,7 +116,7 @@ elseif minetest.global_exists("inventory_plus") then -- inventory++ installed
 
 	--show the form when the button is pressed and hide it when done
 	local gui_player_formspecs = {}
-	minetest.register_on_player_receive_fields(function(player, formname, fields)
+	minetest.register_on_player_receive_fields(function(player, _, fields)
 		local name = player:get_player_name()
 		if fields.worldedit_gui then --main page
 			gui_player_formspecs[name] = player:get_inventory_formspec()
@@ -158,7 +158,7 @@ elseif minetest.global_exists("smart_inventory") then -- smart_inventory install
 		codebox:set_we_formspec("worldedit_gui")
 
 		-- process input (the back button)
-		state:onInput(function(state, fields, player)
+		state:onInput(function(state, fields)
 			if fields.worldedit_gui then --main page
 				state:get("code"):set_we_formspec("worldedit_gui")
 			elseif fields.worldedit_gui_exit then --return to original page
@@ -198,7 +198,7 @@ elseif minetest.global_exists("sfinv") then -- sfinv installed
 	})
 
 	--show the form when the button is pressed and hide it when done
-	minetest.register_on_player_receive_fields(function(player, formname, fields)
+	minetest.register_on_player_receive_fields(function(player, _, fields)
 		if fields.worldedit_gui then --main page
 			worldedit.show_page(player:get_player_name(), "worldedit_gui")
 			return true
@@ -228,12 +228,12 @@ end
 worldedit.register_gui_function("worldedit_gui", {
 	name = "WorldEdit GUI",
 	privs = {interact=true},
-	get_formspec = function(name)
+	get_formspec = function()
 		--create a form with all the buttons arranged in a grid
 		local buttons, x, y, index = {}, 0, 1, 0
 		local width, height = 3, 0.8
 		local columns = 5
-		for i, identifier in pairs(identifiers) do
+		for _, identifier in pairs(identifiers) do
 			if identifier ~= "worldedit_gui" then
 				local entry = worldedit.pages[identifier]
 				table.insert(buttons, string.format((entry.get_formspec and "button" or "button_exit") ..


### PR DESCRIPTION
With luacheck mistakes in lua code can be found, e.g. the use of undefined variables, and the code style can be checked.
I've added a .luacheckrc for WorldEdit, removed trailing whitespace and whitespace before tabs, and removed or renamed unused variables.

I've also changed something in compatibility.lua which was probably wrong:
```
Checking worldedit/compatibility.lua              2 warnings

    worldedit/compatibility.lua:27:40: value of argument filename is overwritten on line 29 before use
    worldedit/compatibility.lua:29:55: accessing undefined variable file
```