### PR TITLE
Fix back button in some worldedit_gui pages

### DIFF
--- a/worldedit_gui/init.lua
+++ b/worldedit_gui/init.lua
@@ -42,7 +42,7 @@ Example:
 worldedit.register_gui_handler = function(identifier, handler)
 	local enabled = true
 	minetest.register_on_player_receive_fields(function(player, formname, fields)
-		if not enabled then return false end
+		if not enabled or formname ~= "" or fields.worldedit_gui then return false end
 		enabled = false
 		minetest.after(0.2, function() enabled = true end)
 		local name = player:get_player_name()


### PR DESCRIPTION
This should fix https://github.com/Uberi/Minetest-WorldEdit/issues/213 by preventing the normal callback from being run if the back button is pressed. I've also added a `formname` check to prevent the GUI handler functions from being run for all formspec input.