### PR TITLE
Remove unused variables and assignments

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -4,5 +4,4 @@ read_globals = {"minetest", "vector", "VoxelArea", "ItemStack",
 }
 globals = {"worldedit"}
 -- Ignore these errors until someone decides to fix them
-ignore = {"211", "212", "213", "311", "411", "412", "421", "422",
-	"431", "432", "631"}
+ignore = {"212", "213", "411", "412", "421", "422", "431", "432", "631"}

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -217,8 +217,6 @@ function worldedit.copy2(pos1, pos2, off, meta_backwards)
 	dst_manip:set_param2_data(dst_data)
 
 	mh.finish(dst_manip)
-	src_data = nil
-	dst_data = nil
 
 	-- Copy metadata
 	local get_meta = minetest.get_meta

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -160,7 +160,7 @@ end
 --- Loads the schematic in `value` into a node list in the latest format.
 -- @return A node list in the latest format, or nil on failure.
 local function load_schematic(value)
-	local version, header, content = worldedit.read_header(value)
+	local version, _, content = worldedit.read_header(value)
 	local nodes = {}
 	if version == 1 or version == 2 then -- Original flat table format
 		local tables = minetest.deserialize(content, true)
@@ -250,7 +250,6 @@ function worldedit.deserialize(origin_pos, value)
 	worldedit.keep_loaded(pos1, pos2)
 
 	local origin_x, origin_y, origin_z = origin_pos.x, origin_pos.y, origin_pos.z
-	local count = 0
 	local add_node, get_meta = minetest.add_node, minetest.get_meta
 	for i, entry in ipairs(nodes) do
 		entry.x, entry.y, entry.z = origin_x + entry.x, origin_y + entry.y, origin_z + entry.z

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -160,7 +160,7 @@ end
 --- Loads the schematic in `value` into a node list in the latest format.
 -- @return A node list in the latest format, or nil on failure.
 local function load_schematic(value)
-	local version, header, content = worldedit.read_header(value)
+	local version, _, content = worldedit.read_header(value)
 	local nodes = {}
 	if version == 1 or version == 2 then -- Original flat table format
 		local tables = minetest.deserialize(content, true)

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -160,7 +160,7 @@ end
 --- Loads the schematic in `value` into a node list in the latest format.
 -- @return A node list in the latest format, or nil on failure.
 local function load_schematic(value)
-	local version, _, content = worldedit.read_header(value)
+	local version, header, content = worldedit.read_header(value)
 	local nodes = {}
 	if version == 1 or version == 2 then -- Original flat table format
 		local tables = minetest.deserialize(content, true)

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -45,14 +45,14 @@ local function chatcommand_handler(cmd_name, name, param)
 	if def.nodes_needed then
 		local count = def.nodes_needed(name, unpack(parsed))
 		safe_region(name, count, function()
-			local success, msg = def.func(name, unpack(parsed))
+			local _, msg = def.func(name, unpack(parsed))
 			if msg then
 				minetest.chat_send_player(name, msg)
 			end
 		end)
 	else
 		-- no "safe region" check
-		local success, msg = def.func(name, unpack(parsed))
+		local _, msg = def.func(name, unpack(parsed))
 		if msg then
 			minetest.chat_send_player(name, msg)
 		end
@@ -296,7 +296,6 @@ worldedit.register_command("help", {
 			return false, "You are not allowed to use any WorldEdit commands."
 		end
 		if param == "" then
-			local msg = ""
 			local cmds = {}
 			for cmd, def in pairs(worldedit.registered_commands) do
 				if minetest.check_player_privs(name, def.privs) then
@@ -1383,7 +1382,7 @@ worldedit.register_command("restore", {
 })
 
 local function detect_misaligned_schematic(name, pos1, pos2)
-	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+	pos1 = worldedit.sort_pos(pos1, pos2)
 	-- Check that allocate/save can position the schematic correctly
 	-- The expected behaviour is that the (0,0,0) corner of the schematic stays
 	-- sat pos1, this only works when the minimum position is actually present

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -45,14 +45,14 @@ local function chatcommand_handler(cmd_name, name, param)
 	if def.nodes_needed then
 		local count = def.nodes_needed(name, unpack(parsed))
 		safe_region(name, count, function()
-			local _, msg = def.func(name, unpack(parsed))
+			local success, msg = def.func(name, unpack(parsed))
 			if msg then
 				minetest.chat_send_player(name, msg)
 			end
 		end)
 	else
 		-- no "safe region" check
-		local _, msg = def.func(name, unpack(parsed))
+		local success, msg = def.func(name, unpack(parsed))
 		if msg then
 			minetest.chat_send_player(name, msg)
 		end
@@ -1382,7 +1382,7 @@ worldedit.register_command("restore", {
 })
 
 local function detect_misaligned_schematic(name, pos1, pos2)
-	pos1 = worldedit.sort_pos(pos1, pos2)
+	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 	-- Check that allocate/save can position the schematic correctly
 	-- The expected behaviour is that the (0,0,0) corner of the schematic stays
 	-- sat pos1, this only works when the minimum position is actually present

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -45,14 +45,14 @@ local function chatcommand_handler(cmd_name, name, param)
 	if def.nodes_needed then
 		local count = def.nodes_needed(name, unpack(parsed))
 		safe_region(name, count, function()
-			local success, msg = def.func(name, unpack(parsed))
+			local _, msg = def.func(name, unpack(parsed))
 			if msg then
 				minetest.chat_send_player(name, msg)
 			end
 		end)
 	else
 		-- no "safe region" check
-		local success, msg = def.func(name, unpack(parsed))
+		local _, msg = def.func(name, unpack(parsed))
 		if msg then
 			minetest.chat_send_player(name, msg)
 		end
@@ -1382,7 +1382,7 @@ worldedit.register_command("restore", {
 })
 
 local function detect_misaligned_schematic(name, pos1, pos2)
-	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
+	pos1 = worldedit.sort_pos(pos1, pos2)
 	-- Check that allocate/save can position the schematic correctly
 	-- The expected behaviour is that the (0,0,0) corner of the schematic stays
 	-- sat pos1, this only works when the minimum position is actually present

--- a/worldedit_commands/mark.lua
+++ b/worldedit_commands/mark.lua
@@ -6,7 +6,7 @@ local init_sentinel = "new" .. tostring(math.random(99999))
 
 --marks worldedit region position 1
 worldedit.mark_pos1 = function(name, region_too)
-	local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]
+	local pos1 = worldedit.pos1[name]
 
 	if worldedit.marker1[name] ~= nil then --marker already exists
 		worldedit.marker1[name]:remove() --remove marker
@@ -30,7 +30,7 @@ end
 
 --marks worldedit region position 2
 worldedit.mark_pos2 = function(name, region_too)
-	local pos1, pos2 = worldedit.pos1[name], worldedit.pos2[name]
+	local pos2 = worldedit.pos2[name]
 
 	if worldedit.marker2[name] ~= nil then --marker already exists
 		worldedit.marker2[name]:remove() --remove marker


### PR DESCRIPTION
The removal of unused variables can improve the detection of mistakes with luacheck;
for example, it can detect if the wrong argument is passed to a function because of a copy-paste mistake.

Setting `src_data` and `dst_data` to `nil` which might enable an earlier garbage collection in `worldedit.stack2` looks like an unneeded micro-optimisation.