### PR TITLE
Add trailing and comment trimming when obtaining dedicated_server_step

### DIFF
--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -101,7 +101,7 @@ end
 local function deferred_execution(next_one, finished)
 	-- Allocate 100% of server step for execution (might lag a little)
 	local allocated_usecs =
-		tonumber(minetest.settings:get("dedicated_server_step")) * 1000000
+		tonumber(minetest.settings:get("dedicated_server_step"):split(" ")[1]) * 1000000
 	local function f()
 		local deadline = minetest.get_us_time() + allocated_usecs
 		repeat


### PR DESCRIPTION
This change trims anything starting with the first space from `dedicated_server_step`, including single-line comments following the configured value specifically, before using it for calculations. It fixes compatibility-breaking crashes with other mods/games, which change the mentioned value by adding a comment after it. Such a comment is, as far as I know, syntactically valid, and is accepted by the engine it seems (as without WorldEdit those mods/games work).

As an example of the mentioned crash could be taken MineClone2, which alone works of course, but crashes when combined with WorldEdit, because MCL2 changes the `dedicated_server_step` to `0.05 #tick rate`, which can't be parsed by tonumber() and causes a crash due to attempt to perform arithmetic on nil.