### PR TITLE
Make //lua work with expressions as well

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,6 +1,7 @@
 read_globals = {"minetest", "vector", "VoxelArea", "ItemStack",
 	"table",
-	"unified_inventory", "sfinv", "smart_inventory", "inventory_plus"
+	"unified_inventory", "sfinv", "smart_inventory", "inventory_plus",
+	"dump"
 }
 globals = {"worldedit"}
 -- Ignore these errors until someone decides to fix them

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -227,11 +227,17 @@ Code
 ----
 Contained in code.lua, this module allows arbitrary Lua code to be used with WorldEdit.
 
-### error = worldedit.lua(code)
+### error = worldedit.lua(code,name)
 
-Executes `code` as a Lua chunk in the global namespace.
+the given code gets encapsulated into a function with parameters `name`, `player`, pos`
+where
+ * `name` is a playername or `nil`
+ * `player` is the player object of the above player if applicable, otherwise `nil`
+ * `pos` is the position of the aforementioned player (if applicable, otherwise `nil`) rounded to integers
 
-Returns an error if the code fails or nil otherwise.
+the resulting function is then executed as a Lua chunk in the global namespace.
+
+The return is a tuple of success and return of the function converted to a string, which in turn serves as an error messsage in case of a failure
 
 ### error = worldedit.luatransform(pos1, pos2, code)
 

--- a/WorldEdit API.md
+++ b/WorldEdit API.md
@@ -227,9 +227,9 @@ Code
 ----
 Contained in code.lua, this module allows arbitrary Lua code to be used with WorldEdit.
 
-### error = worldedit.lua(code,name)
+### error = worldedit.lua(code, name)
 
-the given code gets encapsulated into a function with parameters `name`, `player`, pos`
+the given code gets encapsulated into a function with parameters `name`, `player`, `pos`
 where
  * `name` is a playername or `nil`
  * `player` is the player object of the above player if applicable, otherwise `nil`
@@ -237,7 +237,9 @@ where
 
 the resulting function is then executed as a Lua chunk in the global namespace.
 
-The return is a tuple of success and return of the function converted to a string, which in turn serves as an error messsage in case of a failure
+The return is
+ * a string in case of an error
+ * a tuple of `nil` and return of the function converted to a string in case of success
 
 ### error = worldedit.luatransform(pos1, pos2, code)
 

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -23,7 +23,6 @@ function worldedit.lua(code, name)
 	local good, err = pcall(func, name, player, pos)
 	if not good then -- Runtime error
 		return tostring(err)
-		
 	end
 	return nil, dump(err)
 end

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -4,31 +4,28 @@
 --- Executes `code` as a Lua chunk in the global namespace.
 -- the code will be encapsulated into a function with parameters
 --  * name (the name of the player issuing the //lua command)
---  * player (the player object of the above player if applicable)
---  * pos (the position of the aforementioned player (if applicable) rounded to integers
+--  * player (the player object of the player)
+--  * pos (the position of the player rounded to integers)
 -- @return string in case of error, tuple of nil, return of code as string in case of success
 function worldedit.lua(code, name)
-	if string.sub(code, 1, 1) == "=" then
-		code = "return " .. string.sub(code, 2)
-	end
-	local factory, err = loadstring("return function(name, player, pos) " .. code .. " end")
-	if not factory then  -- Syntax error
+	local factory, err = loadstring("return function(name, player, pos)\n" .. code .. "\nend")
+	if not factory then -- Syntax error
 		return err
 	end
-	local func=factory()
-	local player
+	local func = factory()
+	local player, pos
 	if name then
 		player = minetest.get_player_by_name(name)
-	end
-	local pos
-	if player then
-		pos = vector.round(player:get_pos())
+		if player then
+			pos = vector.round(player:get_pos())
+		end
 	end
 	local good, err = pcall(func, name, player, pos)
-	if good then
-		return nil, dump(err)
+	if not good then -- Runtime error
+		return tostring(err)
+		
 	end
-	return err
+	return nil, dump(err)
 end
 
 

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -13,22 +13,22 @@ function worldedit.lua(code, name)
 	end
 	local factory, err = loadstring("return function(name, player, pos) " .. code .. " end")
 	if not factory then  -- Syntax error
-		return false, err
+		return err
 	end
 	local func=factory()
 	local player
 	if name then
-		player=minetest.get_player_by_name(name)
+		player = minetest.get_player_by_name(name)
 	end
 	local pos
 	if player then
-		pos=vector.round(player:get_pos())
+		pos = vector.round(player:get_pos())
 	end
 	local good, err = pcall(func, name, player, pos)
 	if good then
-		err=dump(err)
+		return nil, dump(err)
 	end
-	return good, err
+	return err
 end
 
 

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -3,16 +3,22 @@
 
 --- Executes `code` as a Lua chunk in the global namespace.
 -- @return An error message if the code fails, or nil on success.
-function worldedit.lua(code)
-	local func, err = loadstring(code)
-	if not func then  -- Syntax error
-		return err
+function worldedit.lua(code, name)
+	local factory, err = loadstring("return function(p) " .. code .. " end")
+	if not factory then  -- Syntax error
+		return false, err
 	end
-	local good, err = pcall(func)
-	if not good then  -- Runtime error
-		return err
+	local func=factory()
+	local player=minetest.get_player_by_name(name)
+	local p={name=name, player=player}
+	if player then
+		p["pos"]=vector.round(player:get_pos())
 	end
-	return nil
+	local good, err = pcall(func, p)
+	if good then
+		err=dump(err)
+	end
+	return good, err
 end
 
 

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -2,22 +2,29 @@
 -- @module worldedit.code
 
 --- Executes `code` as a Lua chunk in the global namespace.
--- @return An error message if the code fails, or nil on success.
+-- the code will be encapsulated into a function with parameters
+--  * name (the name of the player issuing the //lua command)
+--  * player (the player object of the above player if applicable)
+--  * pos (the position of the aforementioned player (if applicable) rounded to integers
+-- @return tuple of success, return of code as string (error message in case of failure)
 function worldedit.lua(code, name)
 	if string.sub(code,1,1)=="=" then
 		code="return "..string.sub(code,2)
 	end
-	local factory, err = loadstring("return function(p) " .. code .. " end")
+	local factory, err = loadstring("return function(name, player, pos) " .. code .. " end")
 	if not factory then  -- Syntax error
 		return false, err
 	end
 	local func=factory()
-	local player=minetest.get_player_by_name(name)
-	local p={name=name, player=player}
-	if player then
-		p["pos"]=vector.round(player:get_pos())
+	local player
+	if name then
+		player=minetest.get_player_by_name(name)
 	end
-	local good, err = pcall(func, p)
+	local pos
+	if player then
+		pos=vector.round(player:get_pos())
+	end
+	local good, err = pcall(func, name, player, pos)
 	if good then
 		err=dump(err)
 	end

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -6,10 +6,10 @@
 --  * name (the name of the player issuing the //lua command)
 --  * player (the player object of the above player if applicable)
 --  * pos (the position of the aforementioned player (if applicable) rounded to integers
--- @return tuple of success, return of code as string (error message in case of failure)
+-- @return string in case of error, tuple of nil, return of code as string in case of success
 function worldedit.lua(code, name)
-	if string.sub(code,1,1)=="=" then
-		code="return "..string.sub(code,2)
+	if string.sub(code, 1, 1) == "=" then
+		code = "return " .. string.sub(code, 2)
 	end
 	local factory, err = loadstring("return function(name, player, pos) " .. code .. " end")
 	if not factory then  -- Syntax error

--- a/worldedit/code.lua
+++ b/worldedit/code.lua
@@ -4,6 +4,9 @@
 --- Executes `code` as a Lua chunk in the global namespace.
 -- @return An error message if the code fails, or nil on success.
 function worldedit.lua(code, name)
+	if string.sub(code,1,1)=="=" then
+		code="return "..string.sub(code,2)
+	end
 	local factory, err = loadstring("return function(p) " .. code .. " end")
 	if not factory then  -- Syntax error
 		return false, err

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -1525,20 +1525,27 @@ worldedit.register_command("lua", {
 	description = S("Executes <code> as a Lua chunk in the global namespace"),
 	privs = {worldedit=true, server=true},
 	parse = function(param)
+		if param == "" then
+			return false
+		end
 		return true, param
 	end,
 	func = function(name, param)
-		local ret = {worldedit.lua(param, name)}
-		if type(ret[1]) == "nil" then
-			if ret[2] ~= "nil" then
-				worldedit.player_notify(name, "code successfully executed, returns with " .. ret[2], false)
-			else
-				worldedit.player_notify(name, "code successfully executed", false)
-			end
+		-- shorthand like in the Lua interpreter
+		if param:sub(1, 1) == "=" then
+			param = "return " .. param:sub(2)
+		end
+		local err, ret = worldedit.lua(param, name)
+		if err == nil then
 			minetest.log("action", name .. " executed " .. param)
+			if ret ~= "nil" then
+				worldedit.player_notify(name, "code successfully executed, returned " .. ret)
+			else
+				worldedit.player_notify(name, "code successfully executed")
+			end
 		else
-			worldedit.player_notify(name, "code error: " .. dump(ret[1]))
 			minetest.log("action", name .. " tried to execute " .. param)
+			worldedit.player_notify(name, "code error: " .. err)
 		end
 	end,
 })

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -1530,7 +1530,11 @@ worldedit.register_command("lua", {
 	func = function(name, param)
 		local good, ret = worldedit.lua(param, name)
 		if good then
-			worldedit.player_notify(name, "code successfully executed, returns with " .. ret, false)
+			if ret ~= "nil" then
+				worldedit.player_notify(name, "code successfully executed, returns with " .. ret, false)
+			else
+				worldedit.player_notify(name, "code successfully executed", false)
+			end
 			minetest.log("action", name .. " executed " .. param)
 		else
 			worldedit.player_notify(name, "code error: " .. dump(ret))

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -1528,16 +1528,16 @@ worldedit.register_command("lua", {
 		return true, param
 	end,
 	func = function(name, param)
-		local good, ret = worldedit.lua(param, name)
-		if good then
-			if ret ~= "nil" then
-				worldedit.player_notify(name, "code successfully executed, returns with " .. ret, false)
+		local ret = {worldedit.lua(param, name)}
+		if type(ret[1]) == "nil" then
+			if ret[2] ~= "nil" then
+				worldedit.player_notify(name, "code successfully executed, returns with " .. ret[2], false)
 			else
 				worldedit.player_notify(name, "code successfully executed", false)
 			end
 			minetest.log("action", name .. " executed " .. param)
 		else
-			worldedit.player_notify(name, "code error: " .. dump(ret))
+			worldedit.player_notify(name, "code error: " .. dump(ret[1]))
 			minetest.log("action", name .. " tried to execute " .. param)
 		end
 	end,

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -1528,13 +1528,13 @@ worldedit.register_command("lua", {
 		return true, param
 	end,
 	func = function(name, param)
-		local err = worldedit.lua(param)
-		if err then
-			worldedit.player_notify(name, "code error: " .. err)
-			minetest.log("action", name.." tried to execute "..param)
+		local good, ret = worldedit.lua(param, name)
+		if good then
+			worldedit.player_notify(name, "code successfully executed, returns with " .. ret, false)
+			minetest.log("action", name .. " executed " .. param)
 		else
-			worldedit.player_notify(name, "code successfully executed", false)
-			minetest.log("action", name.." executed "..param)
+			worldedit.player_notify(name, "code error: " .. dump(ret))
+			minetest.log("action", name .. " tried to execute " .. param)
 		end
 	end,
 })


### PR DESCRIPTION
Hello,

so with this patch you can do something like `//lua return minetest.get_node_light(p.pos)` I think this is a useful development helper tool for mod developers, maybe it can save you 1-2 server restarts. Also it is backwards compatible: every `//lua` command that used to work will still work