### PR TITLE
//clearobjects should remove unknown objects

### DIFF
--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -640,6 +640,9 @@ function worldedit.clear_objects(pos1, pos2)
 
 	local function should_delete(obj)
 		-- Avoid players and WorldEdit entities
+		if obj:is_player() then
+			return false
+		end
 		local entity = obj:get_luaentity()
 		return not (entity and entity.name:find("^worldedit:"))
 	end

--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -640,11 +640,8 @@ function worldedit.clear_objects(pos1, pos2)
 
 	local function should_delete(obj)
 		-- Avoid players and WorldEdit entities
-		if obj:is_player() then
-			return false
-		end
 		local entity = obj:get_luaentity()
-		return not entity or not entity.name:find("^worldedit:")
+		return not (entity and entity.name:find("^worldedit:"))
 	end
 
 	-- Offset positions to include full nodes (positions are in the center of nodes)
@@ -691,4 +688,3 @@ function worldedit.clear_objects(pos1, pos2)
 	end
 	return count
 end
-


### PR DESCRIPTION
currently, `//clearobjects` will not remove unknown objects. for unknown objects, `minetest.is_player(obj)` is `false`, and `obj:get_luaentity()` is `nil`. calling `obj:remove()` on a player is a no-op, [per the documentation](https://github.com/minetest/minetest/blob/master/doc/lua_api.md#lua-entity-only-no-op-for-other-objects). 