### PR TITLE
Allow the wielded item to be specified in commands

### DIFF
--- a/worldedit_brush/init.lua
+++ b/worldedit_brush/init.lua
@@ -39,7 +39,7 @@ local brush_on_use = function(itemstack, placer)
 	worldedit.marker_update(name)
 
 	assert(cmddef.require_pos < 2)
-	local parsed = {cmddef.parse(meta:get_string("params"))}
+	local parsed = {cmddef.parse(meta:get_string("params"), name)}
 	if not table.remove(parsed, 1) then return false end -- shouldn't happen
 
 	-- discard success messages
@@ -104,7 +104,7 @@ worldedit.register_command("brush", {
 			end
 
 			-- Try parsing command params so we can give the user feedback
-			local ok, err = cmddef.parse(params)
+			local ok, err = cmddef.parse(params, name)
 			if not ok then
 				err = err or S("invalid usage")
 				return false, S("Error with command: @1", err)

--- a/worldedit_commands/cuboid.lua
+++ b/worldedit_commands/cuboid.lua
@@ -218,7 +218,7 @@ worldedit.register_command("cubeapply", {
 	description = S("Select a cube with side length <size> around position 1 and run <command> on region"),
 	privs = {worldedit=true},
 	require_pos = 1,
-	parse = function(param)
+	parse = function(param, playername)
 		local found, _, sidex, sidey, sidez, cmd, args =
 			param:find("^(%d+)%s+(%d+)%s+(%d+)%s+([^%s]+)%s*(.*)$")
 		if found == nil then
@@ -241,7 +241,7 @@ worldedit.register_command("cubeapply", {
 				minetest.colorize("#00ffff", "//"..cmd))
 		end
 		-- run parsing of target command
-		local parsed = {cmddef.parse(args)}
+		local parsed = {cmddef.parse(args, playername)}
 		if not table.remove(parsed, 1) then
 			return false, parsed[1]
 		end

--- a/worldedit_commands/init.lua
+++ b/worldedit_commands/init.lua
@@ -42,7 +42,7 @@ local function chatcommand_handler(cmd_name, name, param)
 		end
 	end
 
-	local parsed = {def.parse(param)}
+	local parsed = {def.parse(param, name)}
 	local success = table.remove(parsed, 1)
 	if not success then
 		worldedit.player_notify(name, parsed[1] or S("invalid usage"), "error")

--- a/worldedit_commands/manipulations.lua
+++ b/worldedit_commands/manipulations.lua
@@ -42,10 +42,10 @@ worldedit.register_command("set", {
 	category = S("Node manipulation"),
 	privs = {worldedit=true},
 	require_pos = 2,
-	parse = function(param)
-		local node = worldedit.normalize_nodename(param)
+	parse = function(param, player)
+		local node, err = worldedit.normalize_nodename(param, player)
 		if not node then
-			return false, S("invalid node name: @1", param)
+			return false, err
 		end
 		return true, node
 	end,
@@ -84,7 +84,7 @@ worldedit.register_command("mix", {
 	category = S("Node manipulation"),
 	privs = {worldedit=true},
 	require_pos = 2,
-	parse = function(param)
+	parse = function(param, playername)
 		local nodes = {}
 		for nodename in param:gmatch("[^%s]+") do
 			if tonumber(nodename) ~= nil and #nodes > 0 then
@@ -93,9 +93,9 @@ worldedit.register_command("mix", {
 					nodes[#nodes + 1] = last_node
 				end
 			else
-				local node = worldedit.normalize_nodename(nodename)
+				local node, err = worldedit.normalize_nodename(nodename, playername)
 				if not node then
-					return false, S("invalid node name: @1", nodename)
+					return false, err
 				end
 				nodes[#nodes + 1] = node
 			end
@@ -113,18 +113,18 @@ worldedit.register_command("mix", {
 	end,
 })
 
-local check_replace = function(param)
+local check_replace = function(param, playername)
 	local found, _, searchnode, replacenode = param:find("^([^%s]+)%s+(.+)$")
 	if found == nil then
 		return false
 	end
-	local newsearchnode = worldedit.normalize_nodename(searchnode)
+	local newsearchnode, err = worldedit.normalize_nodename(searchnode, playername)
 	if not newsearchnode then
-		return false, S("invalid search node name: @1", searchnode)
+		return false, err
 	end
-	local newreplacenode = worldedit.normalize_nodename(replacenode)
+	local newreplacenode, err = worldedit.normalize_nodename(replacenode, playername)
 	if not newreplacenode then
-		return false, S("invalid replace node name: @1", replacenode)
+		return false, err
 	end
 	return true, newsearchnode, newreplacenode
 end
@@ -318,10 +318,10 @@ worldedit.register_command("suppress", {
 	category = S("Node manipulation"),
 	privs = {worldedit=true},
 	require_pos = 2,
-	parse = function(param)
-		local node = worldedit.normalize_nodename(param)
+	parse = function(param, playername)
+		local node, err = worldedit.normalize_nodename(param, playername)
 		if not node then
-			return false, S("invalid node name: @1", param)
+			return false, err
 		end
 		return true, node
 	end,
@@ -338,10 +338,10 @@ worldedit.register_command("highlight", {
 	category = S("Node manipulation"),
 	privs = {worldedit=true},
 	require_pos = 2,
-	parse = function(param)
-		local node = worldedit.normalize_nodename(param)
+	parse = function(param, playername)
+		local node, err = worldedit.normalize_nodename(param, playername)
 		if not node then
-			return false, S("invalid node name: @1", param)
+			return false, err
 		end
 		return true, node
 	end,

--- a/worldedit_commands/primitives.lua
+++ b/worldedit_commands/primitives.lua
@@ -1,14 +1,14 @@
 local S = minetest.get_translator("worldedit_commands")
 
 
-local check_cube = function(param)
+local check_cube = function(param, playername)
 	local found, _, w, h, l, nodename = param:find("^(%d+)%s+(%d+)%s+(%d+)%s+(.+)$")
 	if found == nil then
 		return false
 	end
-	local node = worldedit.normalize_nodename(nodename)
+	local node, err = worldedit.normalize_nodename(nodename, playername)
 	if not node then
-		return false, S("invalid node name: @1", nodename)
+		return false, err
 	end
 	return true, tonumber(w), tonumber(h), tonumber(l), node
 end
@@ -45,14 +45,14 @@ worldedit.register_command("cube", {
 	end,
 })
 
-local check_sphere = function(param)
+local check_sphere = function(param, playername)
 	local found, _, radius, nodename = param:find("^(%d+)%s+(.+)$")
 	if found == nil then
 		return false
 	end
-	local node = worldedit.normalize_nodename(nodename)
+	local node, err = worldedit.normalize_nodename(nodename, playername)
 	if not node then
-		return false, S("invalid node name: @1", nodename)
+		return false, err
 	end
 	return true, tonumber(radius), node
 end
@@ -89,14 +89,14 @@ worldedit.register_command("sphere", {
 	end,
 })
 
-local check_dome = function(param)
+local check_dome = function(param, playername)
 	local found, _, radius, nodename = param:find("^(%d+)%s+(.+)$")
 	if found == nil then
 		return false
 	end
-	local node = worldedit.normalize_nodename(nodename)
+	local node, err = worldedit.normalize_nodename(nodename, playername)
 	if not node then
-		return false, S("invalid node name: @1", nodename)
+		return false, err
 	end
 	return true, tonumber(radius), node
 end
@@ -133,7 +133,7 @@ worldedit.register_command("dome", {
 	end,
 })
 
-local check_cylinder = function(param)
+local check_cylinder = function(param, playername)
 	-- two radii
 	local found, _, axis, length, radius1, radius2, nodename = param:find("^([xyz%?])%s+([+-]?%d+)%s+(%d+)%s+(%d+)%s+(.+)$")
 	if found == nil then
@@ -144,9 +144,9 @@ local check_cylinder = function(param)
 	if found == nil then
 		return false
 	end
-	local node = worldedit.normalize_nodename(nodename)
+	local node, err = worldedit.normalize_nodename(nodename, playername)
 	if not node then
-		return false, S("invalid node name: @1", nodename)
+		return false, err
 	end
 	return true, axis, tonumber(length), tonumber(radius1), tonumber(radius2), node
 end
@@ -195,14 +195,14 @@ worldedit.register_command("cylinder", {
 	end,
 })
 
-local check_pyramid = function(param)
+local check_pyramid = function(param, playername)
 	local found, _, axis, height, nodename = param:find("^([xyz%?])%s+([+-]?%d+)%s+(.+)$")
 	if found == nil then
 		return false
 	end
-	local node = worldedit.normalize_nodename(nodename)
+	local node, err = worldedit.normalize_nodename(nodename, playername)
 	if not node then
-		return false, S("invalid node name: @1", nodename)
+		return false, err
 	end
 	return true, axis, tonumber(height), node
 end
@@ -255,14 +255,14 @@ worldedit.register_command("spiral", {
 	category = S("Shapes"),
 	privs = {worldedit=true},
 	require_pos = 1,
-	parse = function(param)
+	parse = function(param, playername)
 		local found, _, length, height, space, nodename = param:find("^(%d+)%s+(%d+)%s+(%d+)%s+(.+)$")
 		if found == nil then
 			return false
 		end
-		local node = worldedit.normalize_nodename(nodename)
+		local node, err = worldedit.normalize_nodename(nodename, playername)
 		if not node then
-			return false, S("invalid node name: @1", nodename)
+			return false, err
 		end
 		return true, tonumber(length), tonumber(height), tonumber(space), node
 	end,


### PR DESCRIPTION
The implementation for https://github.com/Uberi/Minetest-WorldEdit/issues/249

It use either `w` or `wielded` for using the user wielded object. It properly check for all possible case of error I can think of, and is not available in the GUI.

(I think that replacing the `w` or `wielded` text with the currently wielded item would avoid the complexity of refreshing the UI whenever the player change item, but it also mean understanding how to set the GUI searchbox.)

It’s the first time I code on a Minetest mod.

I modified the function signature in a way that should allow mods that does not provide the playername keep working, and mods that does provide the playername with an older worldedit version also works.