### PR TITLE
Add feature to set param2 of specified nodes only

### DIFF
--- a/worldedit/manipulations.lua
+++ b/worldedit/manipulations.lua
@@ -42,16 +42,23 @@ end
 -- @param pos1
 -- @param pos2
 -- @param param2 Value of param2 to set
+-- @param node Optional specified node to affect
 -- @return The number of nodes set.
-function worldedit.set_param2(pos1, pos2, param2)
+function worldedit.set_param2(pos1, pos2, param2, node)
 	pos1, pos2 = worldedit.sort_pos(pos1, pos2)
 
 	local manip, area = mh.init(pos1, pos2)
 	local param2_data = manip:get_param2_data()
+	local data = manip:get_data()
 
-	-- Set param2 for every node
+	local search_id = node and minetest.get_content_id(node)
+	local count = 0
+	-- Set param2 for every node or only for specified nodes
 	for i in area:iterp(pos1, pos2) do
-		param2_data[i] = param2
+		if not search_id or data[i] == search_id then
+			param2_data[i] = param2
+			count = count + 1
+		end
 	end
 
 	-- Update map
@@ -59,7 +66,7 @@ function worldedit.set_param2(pos1, pos2, param2)
 	manip:write_to_map()
 	manip:update_map()
 
-	return worldedit.volume(pos1, pos2)
+	return count
 end
 
 --- Replaces all instances of `search_node` with `replace_node` in a region.

--- a/worldedit_commands/manipulations.lua
+++ b/worldedit_commands/manipulations.lua
@@ -57,23 +57,24 @@ worldedit.register_command("set", {
 })
 
 worldedit.register_command("param2", {
-	params = "<param2>",
-	description = S("Set param2 of all nodes in the current WorldEdit region to <param2>"),
+	params = "<param2> [node]",
+	description = S("Set param2 of all or specified nodes in the current WorldEdit region to <param2>"),
 	category = S("Node manipulation"),
 	privs = {worldedit=true},
 	require_pos = 2,
 	parse = function(param)
-		local param2 = tonumber(param)
+		local param2, node = param:match("^(%d+) (%S+)$")
+		param2 = tonumber(param2) or tonumber(param)
 		if not param2 then
 			return false
 		elseif param2 < 0 or param2 > 255 then
 			return false, S("Param2 is out of range (must be between 0 and 255 inclusive!)")
 		end
-		return true, param2
+		return true, param2, node
 	end,
 	nodes_needed = check_region,
-	func = function(name, param2)
-		local count = worldedit.set_param2(worldedit.pos1[name], worldedit.pos2[name], param2)
+	func = function(name, param2, node)
+		local count = worldedit.set_param2(worldedit.pos1[name], worldedit.pos2[name], param2, node)
 		return true, S("@1 nodes altered", count)
 	end,
 })


### PR DESCRIPTION
This PR allows to set param2 to specified nodes and not to whole region. Old functionality retained.
* For example, `//param2 3 default:locked_chest` will set param2 of all locked chests to 3, untouching other nodes.
### Possible related ideas
* Implement the same feature for //rotate, //orient commands