### PR TITLE
horrible fix for horrible hack to match new core.serialize()

### DIFF
--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -114,73 +114,150 @@ function worldedit.serialize(pos1, pos2)
 	return LATEST_SERIALIZATION_HEADER .. result, count
 end
 
+
+-- Replace content strings while preserving their length
+local function replace_content_strings(content)
+	local escaped = content:gsub("\\\\", "@@"):gsub("\\\"", "@@"):gsub("(\"[^\"]*\")", function(s) return string.rep("@", #s) end)
+	return escaped
+end
+
+
+local function table_body_hack(escaped, content, startpos, node_parser)
+	-- XXX: This is a filthy hack that works surprisingly well [until it does not]
+	-- in LuaJIT, `minetest.deserialize` will fail due to the register limit
+	local nodes = {}
+
+	local startpos, startpos1 = startpos, startpos
+	local endpos
+	while true do -- go through each individual node entry (except the last)
+		startpos, endpos = escaped:find("}%s*,%s*{", startpos)
+		if not startpos then
+			break
+		end
+		local current = content:sub(startpos1, startpos)
+		local entry, err = node_parser("return " .. current)
+		if err then
+			return nil, err
+		end
+		if not entry then
+			break
+		end
+		table.insert(nodes, entry)
+		startpos, startpos1 = endpos, endpos
+	end
+
+	startpos = escaped:find("}%s*$", startpos)
+	if not startpos then
+		return nil, "Expected closing } and <eof>"
+	end
+	local final = content:sub(startpos1, startpos - 1) -- cut off the final closing "}"
+	local entry, err = node_parser("return " .. final) -- process the last entry
+	if err then
+		return nil, string.format("final: %s", err)
+	end
+	table.insert(nodes, entry)
+
+	return nodes, err
+end
+
+
+-- Try to parse the `local _ = {}; _[1] = ...` header, saving values
+-- into a table and returning it.
+local function header_hack(escaped, content)
+	-- NOTE: here we assume that the header does not contain word
+	-- "return" in variables or as code. Since strings are
+	-- escaped, we don't care about them.
+
+	-- NOTE: empty capture () captures the current string position (a number)
+	local end_header, start_table_body = escaped:match("^.-()return%s*{()")
+	if not end_header then
+		return nil, "Could not find header and table body"
+	end
+
+	local header = content:sub(1, end_header-1)
+
+	-- not sure schematics can contain these, but this env is
+	-- here for compatibility with current core.serialize()
+	local env = {inf = math.huge, nan = 0/0}
+
+	if type(header) == "string" then
+		-- make local a "global", so it's saved in the environment
+		local str_local = "local "
+		if header:sub(1, #str_local) ~= str_local then
+			return nil, "Expected header starting with `local `"
+		end
+		header = header:sub(#str_local+1)
+
+		local header_func, err1 = loadstring(header, "@header")
+		if not header_func then
+			return nil, err1
+		end
+		setfenv(header_func, env)
+		local ok, err2 = pcall(header_func)
+		if not ok then
+			return nil, err2
+		end
+	else
+		return nil, "Malformed content?"
+	end
+
+	return env, start_table_body
+end
+
+
+-- Try different loading methods depending on interpreter/file format
 local function deserialize_workaround(content)
 	local nodes, err
-	if not minetest.global_exists("jit") then
+	if minetest.global_exists("jit") then
+		if content:match("^%s*return%s*{") then
+			-- file created with old style serialize
+
+			local escaped = replace_content_strings(content)
+			local startpos = escaped:match("^%s*return%s*{()")
+
+			local core_deserialize = minetest.deserialize
+			local function exec_safe(str)
+				return core_deserialize(str, true)
+			end
+			nodes, err = table_body_hack(escaped, content, startpos, exec_safe)
+		elseif content:match("^local%s+_%s*=%s*{};") then
+			-- file with a "header" at the start
+
+			local escaped = replace_content_strings(content)
+			local env_or_nil, value = header_hack(escaped, content)
+
+			if type(env_or_nil) == "table" then
+				local env = env_or_nil
+				local start_table_body = value
+				local function exec_with_header(code)
+					local func, err = loadstring(code)
+					if not func then
+						return nil, err
+					end
+					setfenv(func, env)
+					local ok, value_or_err = pcall(func)
+					if not ok then
+						return nil, value_or_err
+					end
+					return value_or_err
+				end
+
+				nodes, err = table_body_hack(escaped, content, start_table_body, exec_with_header)
+			else
+				err = value
+			end
+		else
+			-- The data doesn't look like we expect it to so we can't apply the workaround.
+			err = "can't recognize file format"
+		end
+		if not nodes then
+			minetest.log("warning", string.format("WorldEdit: deserializing data but can't apply LuaJIT workaround: %s", err or ""))
+		end
+	end
+
+	-- fallback to default deserialize if previous attempts produced nothing
+	if not nodes then
 		nodes, err = minetest.deserialize(content, true)
-	elseif not (content:match("^local%s+_%s*=%s*{};") or content:match("^%s*return%s*{")) then
-		-- The data doesn't look like we expect it to so we can't apply the workaround.
-		-- hope for the best
-		minetest.log("warning", "WorldEdit: deserializing data but can't apply LuaJIT workaround")
-		nodes, err = minetest.deserialize(content, true)
-	else
-		local header, table_body = content:match("^(.-)return%s*{(.*)}%s*$")
-		local env = {inf = math.huge, nan = 0/0}
-		if header then
-			header = header:gsub("local%s+([%a_][%w_]*)%s*=", "%1 =")
-			local header_func, err1 = loadstring(header, "@header")
-			if not header_func then
-				minetest.log("warning", "WorldEdit: deserialize: " .. err1)
-				return
-			end
-			setfenv(header_func, env)
-			local ok, err2 = pcall(header_func)
-			if not ok then
-				minetest.log("warning", "WorldEdit: deserialize: " .. err2)
-				return
-			end
-		end
-
-		local function exec_with_header(code)
-			local func, err = loadstring(code)
-			if not func then
-				return nil, err -- TODO check for nil in the caller
-			end
-			setfenv(func, env)
-			local ok, value_or_err = pcall(func)
-			if not ok then
-				return nil, value_or_err
-			end
-			return value_or_err
-		end
-
-		-- XXX: This is a filthy hack that works surprisingly well
-		-- in LuaJIT, `minetest.deserialize` will fail due to the register limit
-		nodes = {}
-
-		content = table_body
-		-- remove string contents strings while preserving their length
-		local escaped = content:gsub("\\\\", "@@"):gsub("\\\"", "@@"):gsub("(\"[^\"]*\")", function(s) return string.rep("@", #s) end)
-		local startpos, startpos1 = 1, 1
-		local endpos
-		local entry
-		while true do -- go through each individual node entry (except the last)
-			startpos, endpos = escaped:find("}%s*,%s*{", startpos)
-			if not startpos then
-				break
-			end
-			local current = content:sub(startpos1, startpos)
-			entry, err = exec_with_header("return " .. current)
-			if not entry then
-				break
-			end
-			table.insert(nodes, entry)
-			startpos, startpos1 = endpos, endpos
-		end
-		if not err then
-			entry = exec_with_header("return " .. content:sub(startpos1)) -- process the last entry
-			table.insert(nodes, entry)
-		end
 	end
 	if err then
 		minetest.log("warning", "WorldEdit: deserialize: " .. err)

--- a/worldedit/serialization.lua
+++ b/worldedit/serialization.lua
@@ -118,16 +118,47 @@ local function deserialize_workaround(content)
 	local nodes, err
 	if not minetest.global_exists("jit") then
 		nodes, err = minetest.deserialize(content, true)
-	elseif not content:match("^%s*return%s*{") then
+	elseif not (content:match("^local%s+_%s*=%s*{};") or content:match("^%s*return%s*{")) then
 		-- The data doesn't look like we expect it to so we can't apply the workaround.
 		-- hope for the best
 		minetest.log("warning", "WorldEdit: deserializing data but can't apply LuaJIT workaround")
 		nodes, err = minetest.deserialize(content, true)
 	else
+		local header, table_body = content:match("^(.-)return%s*{(.*)}%s*$")
+		local env = {inf = math.huge, nan = 0/0}
+		if header then
+			header = header:gsub("local%s+([%a_][%w_]*)%s*=", "%1 =")
+			local header_func, err1 = loadstring(header, "@header")
+			if not header_func then
+				minetest.log("warning", "WorldEdit: deserialize: " .. err1)
+				return
+			end
+			setfenv(header_func, env)
+			local ok, err2 = pcall(header_func)
+			if not ok then
+				minetest.log("warning", "WorldEdit: deserialize: " .. err2)
+				return
+			end
+		end
+
+		local function exec_with_header(code)
+			local func, err = loadstring(code)
+			if not func then
+				return nil, err -- TODO check for nil in the caller
+			end
+			setfenv(func, env)
+			local ok, value_or_err = pcall(func)
+			if not ok then
+				return nil, value_or_err
+			end
+			return value_or_err
+		end
+
 		-- XXX: This is a filthy hack that works surprisingly well
 		-- in LuaJIT, `minetest.deserialize` will fail due to the register limit
 		nodes = {}
-		content = content:gsub("^%s*return%s*{", "", 1):gsub("}%s*$", "", 1) -- remove the starting and ending values to leave only the node data
+
+		content = table_body
 		-- remove string contents strings while preserving their length
 		local escaped = content:gsub("\\\\", "@@"):gsub("\\\"", "@@"):gsub("(\"[^\"]*\")", function(s) return string.rep("@", #s) end)
 		local startpos, startpos1 = 1, 1
@@ -139,7 +170,7 @@ local function deserialize_workaround(content)
 				break
 			end
 			local current = content:sub(startpos1, startpos)
-			entry, err = minetest.deserialize("return " .. current, true)
+			entry, err = exec_with_header("return " .. current)
 			if not entry then
 				break
 			end
@@ -147,7 +178,7 @@ local function deserialize_workaround(content)
 			startpos, startpos1 = endpos, endpos
 		end
 		if not err then
-			entry = minetest.deserialize("return " .. content:sub(startpos1), true) -- process the last entry
+			entry = exec_with_header("return " .. content:sub(startpos1)) -- process the last entry
 			table.insert(nodes, entry)
 		end
 	end
@@ -264,4 +295,3 @@ function worldedit.deserialize(origin_pos, value)
 	end
 	return #nodes
 end
-


### PR DESCRIPTION
Currently, loading large schematics on luajit fails with:
```
WARNING[Server]: WorldEdit: deserializing data but can't apply LuaJIT workaround
WARNING[Server]: WorldEdit: deserialize: (load):4: main function has more than 65536 constants
```
see https://github.com/Uberi/Minetest-WorldEdit/issues/267

### Why it stopped working:
Currently, there's a hacky workaround for this luajit issue:
https://github.com/Uberi/Minetest-WorldEdit/blob/ded031745a364875d75e7f0b9261d4eb3050a5b1/worldedit/serialization.lua#L117-L158
The workaround just splits text file in smaller parts and loads them separately.

As some point (I guess [this?](https://github.com/luanti-org/luanti/commit/3eafcab64ecaf8d00a9264b441e996825a6a31bd)), `core.serialize()` was changed to add a "header" to the file, defining local variable that stores values for referencing them later, etc.

Since original hacky workaround depends on matching text, addition of this "header" broke it's check and it falls back to default `core.deserialize()`, which can't handle large tables.

I guess this:
https://github.com/Uberi/Minetest-WorldEdit/blob/ded031745a364875d75e7f0b9261d4eb3050a5b1/worldedit/serialization.lua#L127
did not age well :p

### What this PR does:
It splits the lua file into the "header" and "table_body" parts, loading the header separately and creating an environment (which should also match current core.deserialize() environment). Then it continues doing the hacky workaround stuff, loading each separate node using this environment.


<details>
<summary>Just for curious, repro for this "too many constants" issue outside of luanti:</summary>

<p>

### repro.lua

```lua
-- save this file as "repro.lua" and do `luajit repro.lua`
-- get:
-- luajit: repro.lua:1: main function has more than 65536 constants
local filename = "test_file_blah_blah.lua"

do
    local f = io.open(filename, 'w')

    f:write("return {")

    for i=1,70000 do
        f:write("{1},")
    end

    f:write("}")

    f:close()
end


--local hmm = dofile(filename)

local f = io.open(filename, 'r')

local code = f:read("*a")
f:close()

code = "(function() " .. code .. " end)()"

local a, err = loadstring(code)
if a then
    print(a())
else
    print(err)
end
```
</p>
</details>
